### PR TITLE
Bug fix on download

### DIFF
--- a/cdsodatacli/fetch_access_token.py
+++ b/cdsodatacli/fetch_access_token.py
@@ -33,12 +33,13 @@ def get_bearer_access_token(quiet=True, specific_account=None, account_group="lo
         prefix = "curl -s "
     else:
         prefix = "curl "
+    option_insecure = ' --insecure' # added because workers have deprecated SSL certificates
     cmd = (
         prefix
         + " --location --request POST "
         + url_identity
-        + " --header 'Content-Type: application/x-www-form-urlencoded' --data-urlencode 'grant_type=password' --data-urlencode 'username=%s' --data-urlencode 'password=%s' --data-urlencode 'client_id=cdse-public'"
-        % (login, passwd)
+        + " --header 'Content-Type: application/x-www-form-urlencoded' --data-urlencode 'grant_type=password' --data-urlencode 'username=%s' --data-urlencode 'password=%s' --data-urlencode 'client_id=cdse-public' %s"
+        % (login, passwd,option_insecure)
     )
 
     logging.debug("cmd: %s", cmd)


### PR DESCRIPTION
- [x] add  `--insecure` option un `curl` cmd to get the access token (so that workers that don't have up-to-date SSL certificates can still be used for download)
- [x] `try/except` for `ChunkedEncodingError` to fix #46 