### PR TITLE
fix missing `id_original_query` column for json read from cache dir

### DIFF
--- a/cdsodatacli/query.py
+++ b/cdsodatacli/query.py
@@ -619,7 +619,7 @@ def fetch_data_from_urls_sequential(urls, cache_dir) -> pd.DataFrame:
             logging.info("mkdir cache dir: %s", cache_dir)
             os.makedirs(cache_dir)
     # with tqdm(total=len(urls)) as pbar:
-    for ii in tqdm(range(len(urls)),disable=True):
+    for ii in tqdm(range(len(urls)), disable=True):
         # for url in urls:
         url = urls[ii][1]
         index = urls[ii][0]
@@ -634,7 +634,9 @@ def fetch_data_from_urls_sequential(urls, cache_dir) -> pd.DataFrame:
     logging.info("fetch_data_from_urls time:%1.1fsec", processing_time)
     logging.info("counter: %s", cpt)
     if collected_data_final is not None:
-        assert 'id_original_query' in collected_data_final, "id_original_query column missing in collected data"
+        assert (
+            "id_original_query" in collected_data_final
+        ), "id_original_query column missing in collected data"
     return collected_data_final
 
 


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/cdsodatacli/cdsodatacli/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/cdsodatacli/cdsodatacli/blob/master/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
