### PR TITLE
add method `cds_s3_download_one_product()` for downloads

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,36 @@
+name: Build and Deploy Sphinx Docs
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[docs]  # Adjust based on your setup.py/pyproject.toml
+          pip install sphinx
+      
+      - name: Build Sphinx docs
+        run: |
+          cd docs  # Adjust path to your docs directory
+          sphinx-build -b html . _build/html
+      
+      - name: Deploy to GitHub Pages
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/_build/html

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up conda
         uses: conda-incubator/setup-miniconda@v3
         with:
-          environment-file: ci/docs.yaml  # or cdsodatacli-docs.yml
+          environment-file: ci/requirements/docs.yaml
           python-version: "3.11"
 
       - name: Install package

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   build-docs:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,23 +11,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      
+
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
           python-version: "3.11"
-      
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -e .[docs]  # Adjust based on your setup.py/pyproject.toml
           pip install sphinx
-      
+
       - name: Build Sphinx docs
         run: |
           cd docs  # Adjust path to your docs directory
           sphinx-build -b html . _build/html
-      
+
       - name: Deploy to GitHub Pages
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up conda
         uses: conda-incubator/setup-miniconda@v3
         with:
-          environment-file: docs.yaml # or cdsodatacli-docs.yml
+          environment-file: ci/docs.yaml  # or cdsodatacli-docs.yml
           python-version: "3.11"
 
       - name: Install package

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,20 +12,18 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - name: Set up conda
+        uses: conda-incubator/setup-miniconda@v3
         with:
+          environment-file: docs.yaml # or cdsodatacli-docs.yml
           python-version: "3.11"
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e .[docs]  # Adjust based on your setup.py/pyproject.toml
-          pip install sphinx
+      - name: Install package
+        run: pip install -e .[docs]
 
       - name: Build Sphinx docs
         run: |
-          cd docs  # Adjust path to your docs directory
+          cd docs
           sphinx-build -b html . _build/html
 
       - name: Deploy to GitHub Pages

--- a/cdsodatacli/config.yml
+++ b/cdsodatacli/config.yml
@@ -13,3 +13,8 @@ archives:
 test_default_output_directory: "./my_tests"
 # token_directory: "./CDSE_odata_token_access"
 active_session_directory: "./CDSE_odata_active_sessions"
+s3_access_key: None # prefered solution it to use temporary S3 access token generate on the fly
+s3_secret_key: None
+s3_endpoint: "https://eodata.dataspace.copernicus.eu"
+s3_bucket: 'eodata'
+s3_region: 'default'

--- a/cdsodatacli/config.yml
+++ b/cdsodatacli/config.yml
@@ -16,7 +16,8 @@ active_session_directory: "./CDSE_odata_active_sessions"
 s3_access_key: None # prefered solution it to use temporary S3 access token generate on the fly
 s3_secret_key: None
 s3_endpoint: "https://eodata.dataspace.copernicus.eu"
-s3_bucket: 'eodata'
-s3_region: 'default'
-list_sar_unit_private_data: []
+s3_bucket: "eodata"
+s3_region: "default"
+list_sar_unit_private_data:
+  []
   #- S1E

--- a/cdsodatacli/config.yml
+++ b/cdsodatacli/config.yml
@@ -18,3 +18,5 @@ s3_secret_key: None
 s3_endpoint: "https://eodata.dataspace.copernicus.eu"
 s3_bucket: 'eodata'
 s3_region: 'default'
+list_sar_unit_private_data: []
+  #- S1E

--- a/cdsodatacli/download.py
+++ b/cdsodatacli/download.py
@@ -4,6 +4,8 @@ from tqdm import tqdm
 import datetime
 import time
 import os
+import boto3
+from botocore.exceptions import BotoCoreError, ClientError
 import warnings
 import traceback
 import shutil
@@ -165,6 +167,119 @@ def CDS_Odata_download_one_product_v2(
     logging.debug("average download speed: %1.1fMo/sec", speed)
     return speed, status_meaning, safename_base
 
+
+def cds_s3_download_one_product(
+    s3_path,       
+    output_filepath,
+    conf,
+):
+    """
+    Download a single SAFE product via the CDSE S3 endpoint using boto3.
+
+
+    
+    The conf dict must contain:
+        - pre_spool   (str): temp directory for .tmp files
+        - s3_access_key (str): CDSE S3 access key
+        - s3_secret_key (str): CDSE S3 secret key
+        - s3_endpoint   (str): e.g. "https://eodata.dataspace.copernicus.eu"
+        - s3_bucket     (str): e.g. "eodata"
+        - s3_path       (str): prefix inside the bucket, e.g.
+                               "Sentinel-1/SAR/GRD/2022/05/03/S1A_IW_GRDH_1SDV_20220503T000000.SAFE"
+        - s3_region     (str): 'default' CDSE requires "default"
+
+    Argument:
+        s3_path (str): e.g. "Sentinel-1/SAR/GRD/2022/05/03/S1A_IW_GRDH_1SDV_20220503T000000.SAFE"
+        output_filepath (str): output full path when download is finished (not the pre-spool but the spool)
+        conf (dict): configuration see details above
+
+    Returns
+    -------
+        speed         (float): download speed in Mo/second
+        elapsed_time (int): number of seconds to download the product
+        total_mb (int): MegaBytes downloaded (zip)
+        status_meaning (str): human-readable outcome
+        safename_base  (str): basename without .zip
+    """
+
+
+    speed = np.nan
+    status_meaning = "unknown"
+    t0 = time.time()
+
+    safename_base = os.path.basename(output_filepath).replace(".zip", "")
+    output_filepath_tmp = os.path.join(
+        conf["pre_spool"], os.path.basename(output_filepath) + ".tmp"
+    )
+
+    try:
+        s3 = boto3.resource(
+            "s3",
+            endpoint_url=conf["s3_endpoint"],
+            aws_access_key_id=conf["s3_access_key"],
+            aws_secret_access_key=conf["s3_secret_key"],
+            region_name=conf.get("s3_region", "default"),
+        )
+        bucket = s3.Bucket(conf["s3_bucket"])
+
+        # List all objects under the SAFE prefix
+        objects = list(bucket.objects.filter(Prefix=s3_path))
+        if not objects:
+            raise FileNotFoundError(f"No S3 objects found under prefix: {s3_path}")
+
+        total_bytes = sum(obj.size for obj in objects)
+        total_mb = total_bytes / 1e6
+        logging.debug("Total size to download: %.1f Mo", total_mb)
+
+        # For a zipped single-file product, download into tmp then move
+        # For a .SAFE folder (multi-file), download each file in place
+        if len(objects) == 1:
+            obj = objects[0]
+            logging.debug("Downloading single object %s -> %s", obj.key, output_filepath_tmp)
+            bucket.download_file(obj.key, output_filepath_tmp)
+
+            elapsed_time = time.time() - t0
+            speed = total_mb / elapsed_time
+
+            try:
+                shutil.copy2(output_filepath_tmp, output_filepath)
+                os.remove(output_filepath_tmp)
+                os.chmod(output_filepath, mode=0o0775)
+                status_meaning = "Downloaded"
+            except Exception as e:
+                logging.error("Failed to move %s: %s", output_filepath_tmp, e)
+                if os.path.exists(output_filepath_tmp):
+                    os.remove(output_filepath_tmp)
+                status_meaning = "MoveError"
+
+        else:
+            # Multi-file .SAFE: reconstruct directory tree under output_filepath
+            for obj in objects:
+                relative_key = os.path.relpath(obj.key, s3_path)
+                local_file = os.path.join(output_filepath, relative_key)
+                os.makedirs(os.path.dirname(local_file), exist_ok=True)
+                if not obj.key.endswith("/"):  # skip folder pseudo-objects
+                    logging.debug("Downloading %s -> %s", obj.key, local_file)
+                    bucket.download_file(obj.key, local_file)
+
+            elapsed_time = time.time() - t0
+            speed = total_mb / elapsed_time
+            status_meaning = "Downloaded"
+
+    except FileNotFoundError as e:
+        logging.error("S3 product not found: %s", e)
+        status_meaning = "NotFound"
+        elapsed_time = time.time() - t0
+    except (BotoCoreError, ClientError) as e:
+        logging.error("S3 error while downloading %s: %s", output_filepath, e)
+        status_meaning = "S3Error"
+        elapsed_time = time.time() - t0
+        if os.path.exists(output_filepath_tmp):
+            os.remove(output_filepath_tmp)
+
+    logging.debug("time to download this product: %1.1f sec", elapsed_time)
+    logging.debug("average download speed: %1.1f Mo/sec", speed)
+    return speed,elapsed_time,total_mb, status_meaning, safename_base
 
 def filter_product_already_present(
     cpt, df, outputdir, cdsodatacli_conf, force_download=False

--- a/cdsodatacli/download.py
+++ b/cdsodatacli/download.py
@@ -1159,7 +1159,7 @@ def download_list_product_multithread_v4(
     list_safename,
     outputdir,
     account_group,
-    hideProgressBar=False,
+    hideprogressbar=False,
     check_on_disk=True,
     cdsodatacli_conf_file=None,
 ):
@@ -1188,7 +1188,7 @@ def download_list_product_multithread_v4(
     cpt = defaultdict(int)
     cpt["products_in_initial_listing"] = len(list_id)
     conf = get_conf(path_config_file=cdsodatacli_conf_file)
-    if hideProgressBar:
+    if hideprogressbar:
         os.environ["DISABLE_TQDM"] = "True"
     all_speeds = []
     # status, 0->not treated, -1->error download , 1-> successful download

--- a/cdsodatacli/download.py
+++ b/cdsodatacli/download.py
@@ -1154,6 +1154,257 @@ def download_list_product_multithread_v3(
     return df2
 
 
+def download_list_product_multithread_v4(
+    list_id,
+    list_safename,
+    outputdir,
+    account_group,
+    hideProgressBar=False,
+    check_on_disk=True,
+    cdsodatacli_conf_file=None,
+):
+    """
+    v4 is working as deamon like v3 (while loop) multi account round-robin
+      and token semaphore files but using S3 endpoint to download each product
+    In this method is working for a group of account with one or many account.
+    Each account can run 4 parallel sessions.
+
+    Parameters
+    ----------
+    list_id (list): list of satellite product hashs
+    list_safename (list): list of product names
+    outputdir (str): the directory where to store the product collected
+    account_group (str): a group define in the config file with a unique account -> 4 sessions in parallel
+    hideProgressBar (bool): True -> no tqdm progress bar in stdout
+    check_on_disk (bool): True -> if the product is in the spool dir or in archive dir the download is skipped
+    cdsodatacli_conf_file (str): path to the cdsodatacli configuration file [ optional, default is None -> use cdsodatacli default behavior]
+
+    Returns
+    -------
+        df2 (pd.DataFrame):
+    """
+    assert len(list_id) == len(list_safename)
+    logging.info("check_on_disk : %s", check_on_disk)
+    cpt = defaultdict(int)
+    cpt["products_in_initial_listing"] = len(list_id)
+    conf = get_conf(path_config_file=cdsodatacli_conf_file)
+    if hideProgressBar:
+        os.environ["DISABLE_TQDM"] = "True"
+    all_speeds = []
+    # status, 0->not treated, -1->error download , 1-> successful download
+    df = pd.DataFrame(
+        {"safe": list_safename, "status": np.zeros(len(list_safename)), "id": list_id}
+    )
+    force_download = not check_on_disk
+    df2, cpt = filter_product_already_present(
+        cpt, df, outputdir, force_download=force_download, cdsodatacli_conf=conf
+    )
+    t_start_download = time.time()
+    logging.info("%s", cpt)
+    while_loop = 0
+    blacklist = []
+    running_futures = set()
+    future_to_info = {}
+    max_parallel_download = 0
+    # retries = defaultdict(int)
+    pbar = tqdm(total=len(df2))
+    max_parallelism_seek = MAX_SESSION_PER_ACCOUNT * len(conf[account_group])
+    # token = get_access_token(email=specific_account, password=account_passwd)
+    with (ThreadPoolExecutor(max_workers=max_parallelism_seek) as executor,):
+
+        while (df2["status"] == 0).any():
+
+            while_loop += 1
+
+            subset_to_treat = df2[df2["status"] == 0]
+            pbar.set_description(
+                f"loop={while_loop} | OK={cpt['successful_download']} | ERR={sum(v for k,v in cpt.items() if k.startswith('status_') and k != 'status_OK')} | todo={len(subset_to_treat)} | //={len(running_futures)}"
+            )
+            if len(subset_to_treat) == 0:
+                logging.info(
+                    "All the products have been treated (success or error).Nothing to do, exiting loop"
+                )
+                break
+            # get the 4 download session information that can be submit in //
+            df_prod_downloadable = get_sessions_download_available(
+                conf,
+                subset_to_treat,
+                hideProgressBar=True,
+                blacklist=blacklist,
+                logins_group=account_group,
+            )
+            urls_index = list(df_prod_downloadable.index)
+            logging.debug(
+                "while_loop : %s, prod. to treat: %s, %s",
+                while_loop,
+                len(subset_to_treat),
+                cpt,
+            )
+            # if len(df_prod_downloadable) == 0:
+            if len(df_prod_downloadable) == 0:
+                logging.debug("no session available wait a bit")
+                time.sleep(5)
+                continue
+            errors_per_account = defaultdict(int)
+
+            currently_downloading = set(
+                info["safename"] for info in future_to_info.values()
+            )
+            # 1) Submit as many futures as possible
+            while urls_index and len(running_futures) < max_parallelism_seek:
+                url_one_index = urls_index.pop(0)
+                # id_product = subset_to_treat['id'].iloc[url_one_index]
+                # safename_base = subset_to_treat["safe"].iloc[url_one_index]
+                # safename_base = subset_to_treat["safe"].loc[url_one_index]  # label-based
+                safename_base = df_prod_downloadable["safe"].loc[url_one_index]
+                logintobeused = df_prod_downloadable["login"].loc[url_one_index]
+                assert isinstance(safename_base, str)
+                if safename_base in currently_downloading:
+                    logging.debug("skipping %s already being downloaded", safename_base)
+                    continue
+                # (
+                # access_token,
+                # date_generation_access_token,
+                # login,
+                # path_semaphore_token,
+                # ) = get_bearer_access_token(
+                #     conf=conf, specific_account=acount_email,
+                #     account_group=None
+                # )
+                # headers = {"Authorization": "Bearer %s" % access_token}
+                # session.headers.update(headers)
+                # url_product = cdsodatacli_conf_file["URL_download"] % id_product
+                # output_path = subset_to_treat['output_path'].iloc[url_one_index]
+                # future = executor.submit(download, url)
+                # session = df_prod_downloadable["session"].iloc[url_one_index]
+                # header = df_prod_downloadable["header"].iloc[url_one_index]
+                # url_product = df_prod_downloadable["url"].iloc[url_one_index]
+                # output_path = df_prod_downloadable["output_path"].iloc[url_one_index]
+
+                # Corrected lines inside download_list_product_multithread_v3
+                session = df_prod_downloadable["session"].loc[url_one_index]
+                header = df_prod_downloadable["header"].loc[url_one_index]
+                url_product = df_prod_downloadable["url"].loc[url_one_index]
+                output_path = df_prod_downloadable["output_path"].loc[url_one_index]
+                # path_semaphore_token = df_prod_downloadable["token_semaphore"].loc[
+                #     url_one_index
+                # ]  # Added .loc
+
+                # session = df_prod_downloadable["session"].loc[url_one_index]
+                # header = df_prod_downloadable["header"].loc[url_one_index]
+                # url_product = df_prod_downloadable["url"].loc[url_one_index]
+                # output_path = df_prod_downloadable["output_path"].loc[url_one_index]
+                # path_semaphore_token = df_prod_downloadable["token_semaphore"][
+                #     url_one_index
+                # ]
+                future = executor.submit(
+                    CDS_Odata_download_one_product_v2,
+                    session,
+                    header,
+                    url_product,
+                    output_path,
+                    # path_semaphore_token,
+                    conf=conf,
+                )
+                future_to_info[future] = {
+                    "safename": safename_base,
+                    "login": logintobeused,
+                    # "semaphore_token_file": path_semaphore_token,
+                }
+                currently_downloading.add(safename_base)  # mettre à jour immédiatement
+                # retries[safename_base] += 1
+                running_futures.add(future)
+            # small check to know what is the maximum download parallelism we can reach
+            if len(running_futures) > max_parallel_download:
+                max_parallel_download = len(running_futures)
+            # 2) Wait for at least one download to finish
+            done, running_futures = wait(
+                running_futures, timeout=None, return_when=FIRST_COMPLETED
+            )
+
+            # 3) Handle completed downloads
+            for future in done:
+                info = future_to_info.pop(future, {})
+                safename_base = info.get("safename", "unknown")
+                login_used = info.get("login", "unknown")
+                try:
+                    # process result
+                    (
+                        speed,
+                        status_meaning,
+                        safename_base,
+                        # semaphore_token_file,
+                    ) = future.result()
+                    # future_to_info.pop(future, None)
+                except Exception:
+
+                    logging.error(
+                        "Unhandled exception for %s: %s",
+                        safename_base,
+                        traceback.format_exc(),
+                    )
+                    df2.loc[(df2["safe"] == safename_base), "status"] = -1
+                    pbar.update(1)
+                    continue
+
+                logging.debug("remove session semaphore for %s", login_used)
+                remove_semaphore_session_file(
+                    session_dir=conf["active_session_directory"],
+                    safename=safename_base,
+                    login=login_used,
+                )
+
+                # except KeyboardInterrupt:
+                #     cpt["interrupted"] += 1
+                #     raise ("keyboard interrupt")
+                # except:
+                #     logging.error("traceback : %s", traceback.format_exc())
+                #     speed = np.nan
+                #     status_meaning = "DownloadError"
+                if status_meaning == "OK":
+                    df2.loc[(df2["safe"] == safename_base), "status"] = 1
+                    all_speeds.append(speed)
+                    cpt["successful_download"] += 1
+                else:
+                    df2.loc[(df2["safe"] == safename_base), "status"] = -1
+                    errors_per_account[login_used] += 1
+                    logging.info(
+                        "error found for %s meaning %s", login_used, status_meaning
+                    )
+                    # df2["status"][df2["safe"] == safename_base] = -1 # download in error
+                # if retries[safename_base] > MAX_RETRIES:
+                # df2.loc[(df2["safe"] == safename_base),"status"] = -1
+                cpt["status_%s" % status_meaning] += 1
+
+                pbar.update(1)
+
+                # except Exception as e:
+                #     # handle error
+                #     print("Download failed:", e)
+            for acco in errors_per_account:
+                if errors_per_account[acco] >= MAX_SESSION_PER_ACCOUNT:
+                    blacklist.append(acco)
+                    logging.info("%s black listed for next loops", acco)
+    elapsed_time = time.time() - t_start_download
+    logging.info("download over in %f seconds", elapsed_time)
+    logging.info("counter: %s", cpt)
+    logging.info("maximum parallelism reached : %i", max_parallel_download)
+    # safety remove active session, all reamining because of error
+    remove_semaphore_session_file(
+        session_dir=conf["active_session_directory"],
+        safename=None,
+        login=None,
+    )
+
+    if len(all_speeds) > 0:
+        logging.info(
+            "average download speed %1.1f Mo/s (stdev: %1.1f Mo/s)",
+            np.mean(all_speeds),
+            np.std(all_speeds),
+        )
+    return df2
+
+
 def main():
     """
     download data from an existing listing of product

--- a/cdsodatacli/download.py
+++ b/cdsodatacli/download.py
@@ -233,14 +233,14 @@ def cds_s3_download_one_product(
 
         total_bytes = sum(obj.size for obj in objects)
         total_mb = total_bytes / 1e6
-        logging.debug("Total size to download: %.1f Mo", total_mb)
+        logger.debug("Total size to download: %.1f Mo", total_mb)
 
         # For a zipped single-file product, download into tmp then move
         # For a .SAFE folder (multi-file), download each file in place
         if len(objects) == 1:
             obj = objects[0]
-            logging.info("object key: %s, size: %.1f Mo", obj.key, obj.size / 1e6)
-            logging.debug(
+            logger.info("object key: %s, size: %.1f Mo", obj.key, obj.size / 1e6)
+            logger.debug(
                 "Downloading single object %s -> %s", obj.key, output_filepath_tmp
             )
             bucket.download_file(obj.key, output_filepath_tmp)
@@ -254,7 +254,7 @@ def cds_s3_download_one_product(
                 os.chmod(output_filepath, mode=0o0775)
                 status_meaning = "Downloaded"
             except Exception as e:
-                logging.error("Failed to move %s: %s", output_filepath_tmp, e)
+                logger.error("Failed to move %s: %s", output_filepath_tmp, e)
                 if os.path.exists(output_filepath_tmp):
                     os.remove(output_filepath_tmp)
                 status_meaning = "MoveError"
@@ -266,7 +266,7 @@ def cds_s3_download_one_product(
                 local_file = os.path.join(output_filepath, relative_key)
                 os.makedirs(os.path.dirname(local_file), exist_ok=True)
                 if not obj.key.endswith("/"):  # skip folder pseudo-objects
-                    logging.debug("Downloading %s -> %s", obj.key, local_file)
+                    logger.debug("Downloading %s -> %s", obj.key, local_file)
                     bucket.download_file(obj.key, local_file)
 
             elapsed_time = time.time() - t0
@@ -274,11 +274,11 @@ def cds_s3_download_one_product(
             status_meaning = "Downloaded"
 
     except FileNotFoundError as e:
-        logging.error("S3 product not found: %s", e)
+        logger.error("S3 product not found: %s", e)
         status_meaning = "NotFound"
         elapsed_time = time.time() - t0
     except (BotoCoreError, ClientError) as e:
-        logging.error("S3 error while downloading %s: %s", output_filepath, e)
+        logger.error("S3 error while downloading %s: %s", output_filepath, e)
         status_meaning = "S3Error"
         elapsed_time = time.time() - t0
         if os.path.exists(output_filepath_tmp):
@@ -296,8 +296,8 @@ def cds_s3_download_one_product(
                 f"Failed to delete temporary S3 credentials. Status code: {delete_response.status_code}"
             )
 
-    logging.debug("time to download this product: %1.1f sec", elapsed_time)
-    logging.debug("average download speed: %1.1f Mo/sec", speed)
+    logger.debug("time to download this product: %1.1f sec", elapsed_time)
+    logger.debug("average download speed: %1.1f Mo/sec", speed)
     return speed, elapsed_time, total_mb, status_meaning, safename_base
 
 
@@ -1226,7 +1226,7 @@ def download_list_product_multithread_v4(
     assert len(inputdf["S3Path"]) == len(inputdf["safename"])
     if "status" not in inputdf.columns:
         inputdf["status"] = np.zeros(len(inputdf["safename"]))
-    logging.info("check_on_disk : %s", check_on_disk)
+    logger.info("check_on_disk : %s", check_on_disk)
     cpt = defaultdict(int)
     cpt["products_in_initial_listing"] = len(inputdf["S3Path"])
     conf = get_conf(path_config_file=cdsodatacli_conf_file)
@@ -1249,7 +1249,7 @@ def download_list_product_multithread_v4(
         extension="",
     )
     t_start_download = time.time()
-    logging.info("%s", cpt)
+    logger.info("%s", cpt)
     while_loop = 0
     blacklist = []
     running_futures = set()
@@ -1269,7 +1269,7 @@ def download_list_product_multithread_v4(
                 f"loop={while_loop} | OK={cpt['successful_download']} | ERR={sum(v for k,v in cpt.items() if k.startswith('status_') and k != 'status_OK')} | todo={len(subset_to_treat)} | //={len(running_futures)}"
             )
             if len(subset_to_treat) == 0:
-                logging.info(
+                logger.info(
                     "All the products have been treated (success or error).Nothing to do, exiting loop"
                 )
                 break
@@ -1281,7 +1281,7 @@ def download_list_product_multithread_v4(
                 logins_group=account_group,
             )
             urls_index = list(df_prod_downloadable.index)
-            logging.debug(
+            logger.debug(
                 "while_loop : %s, prod. to treat: %s, %s",
                 while_loop,
                 len(subset_to_treat),
@@ -1289,7 +1289,7 @@ def download_list_product_multithread_v4(
             )
             # if len(df_prod_downloadable) == 0:
             if len(df_prod_downloadable) == 0:
-                logging.debug("no session available wait a bit")
+                logger.debug("no session available wait a bit")
                 time.sleep(5)
                 continue
             errors_per_account = defaultdict(int)
@@ -1300,51 +1300,18 @@ def download_list_product_multithread_v4(
             # 1) Submit as many futures as possible
             while urls_index and len(running_futures) < max_parallelism_seek:
                 url_one_index = urls_index.pop(0)
-                # id_product = subset_to_treat['id'].iloc[url_one_index]
-                # safename_base = subset_to_treat["safe"].iloc[url_one_index]
-                # safename_base = subset_to_treat["safe"].loc[url_one_index]  # label-based
+
                 safename_base = df_prod_downloadable["safe"].loc[url_one_index]
                 logintobeused = df_prod_downloadable["login"].loc[url_one_index]
                 assert isinstance(safename_base, str)
                 if safename_base in currently_downloading:
-                    logging.debug("skipping %s already being downloaded", safename_base)
+                    logger.debug("skipping %s already being downloaded", safename_base)
                     continue
-                # (
-                # access_token,
-                # date_generation_access_token,
-                # login,
-                # path_semaphore_token,
-                # ) = get_bearer_access_token(
-                #     conf=conf, specific_account=acount_email,
-                #     account_group=None
-                # )
-                # headers = {"Authorization": "Bearer %s" % access_token}
-                # session.headers.update(headers)
-                # url_product = cdsodatacli_conf_file["URL_download"] % id_product
-                # output_path = subset_to_treat['output_path'].iloc[url_one_index]
-                # future = executor.submit(download, url)
-                # session = df_prod_downloadable["session"].iloc[url_one_index]
-                # header = df_prod_downloadable["header"].iloc[url_one_index]
-                # url_product = df_prod_downloadable["url"].iloc[url_one_index]
-                # output_path = df_prod_downloadable["output_path"].iloc[url_one_index]
 
-                # Corrected lines inside download_list_product_multithread_v3
-                # session = df_prod_downloadable["session"].loc[url_one_index]
                 header = df_prod_downloadable["header"].loc[url_one_index]
-                # url_product = df_prod_downloadable["url"].loc[url_one_index]
                 output_path = df_prod_downloadable["output_path"].loc[url_one_index]
                 s3path = df_prod_downloadable["S3Path"].loc[url_one_index]
-                # path_semaphore_token = df_prod_downloadable["token_semaphore"].loc[
-                #     url_one_index
-                # ]  # Added .loc
 
-                # session = df_prod_downloadable["session"].loc[url_one_index]
-                # header = df_prod_downloadable["header"].loc[url_one_index]
-                # url_product = df_prod_downloadable["url"].loc[url_one_index]
-                # output_path = df_prod_downloadable["output_path"].loc[url_one_index]
-                # path_semaphore_token = df_prod_downloadable["token_semaphore"][
-                #     url_one_index
-                # ]
                 future = executor.submit(
                     cds_s3_download_one_product,
                     s3path,
@@ -1375,19 +1342,16 @@ def download_list_product_multithread_v4(
                 login_used = info.get("login", "unknown")
                 try:
                     # process result
-                    # speed,elapsed_time,total_mb, status_meaning, safename_base
                     (
                         speed,
                         elapsed_time,
                         total_mb,
                         status_meaning,
                         safename_base,
-                        # semaphore_token_file,
                     ) = future.result()
-                    # future_to_info.pop(future, None)
                 except Exception:
 
-                    logging.error(
+                    logger.error(
                         "Unhandled exception for %s: %s",
                         safename_base,
                         traceback.format_exc(),
@@ -1396,7 +1360,7 @@ def download_list_product_multithread_v4(
                     pbar.update(1)
                     continue
 
-                logging.debug("remove session semaphore for %s", login_used)
+                logger.debug("remove session semaphore for %s", login_used)
                 remove_semaphore_session_file(
                     session_dir=conf["active_session_directory"],
                     safename=safename_base,
@@ -1407,7 +1371,7 @@ def download_list_product_multithread_v4(
                 #     cpt["interrupted"] += 1
                 #     raise ("keyboard interrupt")
                 # except:
-                #     logging.error("traceback : %s", traceback.format_exc())
+                #     logger.error("traceback : %s", traceback.format_exc())
                 #     speed = np.nan
                 #     status_meaning = "DownloadError"
                 if status_meaning == "OK" or status_meaning == "Downloaded":
@@ -1419,7 +1383,7 @@ def download_list_product_multithread_v4(
                 else:
                     df2.loc[(df2["safe"] == safename_base), "status"] = -1
                     errors_per_account[login_used] += 1
-                    logging.info(
+                    logger.info(
                         "error found for %s meaning %s", login_used, status_meaning
                     )
                     # df2["status"][df2["safe"] == safename_base] = -1 # download in error
@@ -1435,11 +1399,11 @@ def download_list_product_multithread_v4(
             for acco in errors_per_account:
                 if errors_per_account[acco] >= MAX_SESSION_PER_ACCOUNT:
                     blacklist.append(acco)
-                    logging.info("%s black listed for next loops", acco)
+                    logger.info("%s black listed for next loops", acco)
     elapsed_time = time.time() - t_start_download
-    logging.info("download over in %f seconds", elapsed_time)
-    logging.info("counter: %s", cpt)
-    logging.info("maximum parallelism reached : %i", max_parallel_download)
+    logger.info("download over in %f seconds", elapsed_time)
+    logger.info("counter: %s", cpt)
+    logger.info("maximum parallelism reached : %i", max_parallel_download)
     # safety remove active session, all reamining because of error
     remove_semaphore_session_file(
         session_dir=conf["active_session_directory"],
@@ -1448,19 +1412,19 @@ def download_list_product_multithread_v4(
     )
 
     if len(all_speeds) > 0:
-        logging.info(
+        logger.info(
             "average download speed %1.1f Mo/s (stdev: %1.1f Mo/s)",
             np.mean(all_speeds),
             np.std(all_speeds),
         )
     if len(all_elapsed_time) > 0:
-        logging.info(
+        logger.info(
             "average elapsed time %1.1f s (stdev: %1.1f s)",
             np.mean(all_elapsed_time),
             np.std(all_elapsed_time),
         )
     if len(all_total_mb) > 0:
-        logging.info(
+        logger.info(
             "cumulated size %1.1f Go (average: %1.1f Go)",
             np.sum(all_total_mb) / 1024,
             np.mean(all_total_mb) / 1024,

--- a/cdsodatacli/download.py
+++ b/cdsodatacli/download.py
@@ -970,7 +970,7 @@ def download_list_product_multithread_v3(
     -------
         df2 (pd.DataFrame):
     """
-    
+
     assert len(inputdf["id"]) == len(inputdf["safename"])
     if "status" not in inputdf.columns:
         inputdf["status"] = np.zeros(len(inputdf["safename"]))
@@ -985,8 +985,11 @@ def download_list_product_multithread_v3(
 
     force_download = not check_on_disk
     df2, cpt = filter_product_already_present(
-        cpt, inputdf.rename(columns={"safename": "safe"}),
-          outputdir, force_download=force_download, cdsodatacli_conf=conf
+        cpt,
+        inputdf.rename(columns={"safename": "safe"}),
+        outputdir,
+        force_download=force_download,
+        cdsodatacli_conf=conf,
     )
     t_start_download = time.time()
     logger.info("%s", cpt)

--- a/cdsodatacli/download.py
+++ b/cdsodatacli/download.py
@@ -944,11 +944,10 @@ def download_list_product_sequential(
 
 
 def download_list_product_multithread_v3(
-    list_id,
-    list_safename,
+    inputdf,
     outputdir,
     account_group,
-    hideProgressBar=False,
+    hideprogressbar=False,
     check_on_disk=True,
     cdsodatacli_conf_file=None,
 ):
@@ -960,11 +959,10 @@ def download_list_product_multithread_v3(
 
     Parameters
     ----------
-    list_id (list): list of satellite product hashs
-    list_safename (list): list of product names
+    inputdf (pd.DataFrame): DataFrame containing product information with columns 'id' and 'safename'
     outputdir (str): the directory where to store the product collected
     account_group (str): a group define in the config file with a unique account -> 4 sessions in parallel
-    hideProgressBar (bool): True -> no tqdm progress bar in stdout
+    hideprogressbar (bool): True -> no tqdm progress bar in stdout
     check_on_disk (bool): True -> if the product is in the spool dir or in archive dir the download is skipped
     cdsodatacli_conf_file (str): path to the cdsodatacli configuration file [ optional, default is None -> use cdsodatacli default behavior]
 
@@ -972,21 +970,23 @@ def download_list_product_multithread_v3(
     -------
         df2 (pd.DataFrame):
     """
-    assert len(list_id) == len(list_safename)
+    
+    assert len(inputdf["id"]) == len(inputdf["safename"])
+    if "status" not in inputdf.columns:
+        inputdf["status"] = np.zeros(len(inputdf["safename"]))
     logger.info("check_on_disk : %s", check_on_disk)
     cpt = defaultdict(int)
-    cpt["products_in_initial_listing"] = len(list_id)
+    cpt["products_in_initial_listing"] = len(inputdf["id"])
     conf = get_conf(path_config_file=cdsodatacli_conf_file)
-    if hideProgressBar:
+    if hideprogressbar:
         os.environ["DISABLE_TQDM"] = "True"
     all_speeds = []
     # status, 0->not treated, -1->error download , 1-> successful download
-    df = pd.DataFrame(
-        {"safe": list_safename, "status": np.zeros(len(list_safename)), "id": list_id}
-    )
+
     force_download = not check_on_disk
     df2, cpt = filter_product_already_present(
-        cpt, df, outputdir, force_download=force_download, cdsodatacli_conf=conf
+        cpt, inputdf.rename(columns={"safename": "safe"}),
+          outputdir, force_download=force_download, cdsodatacli_conf=conf
     )
     t_start_download = time.time()
     logger.info("%s", cpt)
@@ -1018,7 +1018,6 @@ def download_list_product_multithread_v3(
             df_prod_downloadable = get_sessions_download_available(
                 conf,
                 subset_to_treat,
-                hideProgressBar=True,
                 blacklist=blacklist,
                 logins_group=account_group,
             )

--- a/cdsodatacli/download.py
+++ b/cdsodatacli/download.py
@@ -31,6 +31,7 @@ from cdsodatacli.utils import (
     check_safe_in_spool,
     check_safe_in_outputdir,
 )
+from cdsodatacli.s3_temporary_access_token import _get_fresh_s3_client
 from cdsodatacli.product_parser import ExplodeSAFE
 from collections import defaultdict
 
@@ -170,6 +171,7 @@ def CDS_Odata_download_one_product_v2(
 
 def cds_s3_download_one_product(
     s3_path,       
+    header,
     output_filepath,
     conf,
 ):
@@ -190,6 +192,7 @@ def cds_s3_download_one_product(
 
     Argument:
         s3_path (str): e.g. "Sentinel-1/SAR/GRD/2022/05/03/S1A_IW_GRDH_1SDV_20220503T000000.SAFE"
+        header (dict): HTTP headers to authenticate the S3 request, if needed (e.g. with temporary token)
         output_filepath (str): output full path when download is finished (not the pre-spool but the spool)
         conf (dict): configuration see details above
 
@@ -204,6 +207,7 @@ def cds_s3_download_one_product(
 
 
     speed = np.nan
+    total_mb = 0
     status_meaning = "unknown"
     t0 = time.time()
 
@@ -211,15 +215,16 @@ def cds_s3_download_one_product(
     output_filepath_tmp = os.path.join(
         conf["pre_spool"], os.path.basename(output_filepath) + ".tmp"
     )
-
+    
     try:
-        s3 = boto3.resource(
-            "s3",
-            endpoint_url=conf["s3_endpoint"],
-            aws_access_key_id=conf["s3_access_key"],
-            aws_secret_access_key=conf["s3_secret_key"],
-            region_name=conf.get("s3_region", "default"),
-        )
+        s3 = _get_fresh_s3_client(conf, headers=header)
+        # s3 = boto3.resource(
+        #     "s3",
+        #     endpoint_url=conf["s3_endpoint"],
+        #     aws_access_key_id=conf["s3_access_key"],
+        #     aws_secret_access_key=conf["s3_secret_key"],
+        #     region_name=conf.get("s3_region", "default"),
+        # )
         bucket = s3.Bucket(conf["s3_bucket"])
 
         # List all objects under the SAFE prefix
@@ -664,43 +669,49 @@ def download_list_product(
     return cpt
 
 
-def test_listing_content(listing_path):
+def test_listing_content(listing_path)->bool:
     """
-    make sure that a lsiting of products to download respect the following format:
-        cdse-hash-id,safename
+    make sure that a listing of products to download respect the following format:
+        cdse-hash-id,safename or s3-path,safename
+
     Arguments:
     ---------
         listing_path (str):
     Returns
     -------
-
+        listing_OK (bool): True -> the listing is OK, False -> the listing is not OK
     """
     fid = open(listing_path)
     first_line = fid.readline()
+    second_line = fid.readline()
     listing_OK = False
-    if "," in first_line:
-        if "SAFE" in first_line.split(",")[1] and "S" in first_line.split(",")[1][0]:
+    if "," in second_line:
+        if "SAFE" in second_line.split(",")[1] and "S" in second_line.split(",")[1][0]:
             listing_OK = True
+    # check that there is a header in the listing.
+    if "safename" in first_line.lower() and ("id" in first_line.lower() or "s3_path" in first_line.lower()):
+        listing_OK = True
     return listing_OK
 
 
 def add_missing_cdse_hash_ids_in_listing(
-    listing_path, display_tqdm=False, email=None, password=None
+    listing_path, conf, display_tqdm=False, email=None, password=None
 ):
     """
-    Add a column of CDSE hash id in a listing of products to download based on the safenames. This is useful for instance for the private data IOC products since the CDSE Odata search does not return the hash id for those products but only the safename. The method is using the same query method as the one used in the CDSE Odata search script (opensearch_private_data_IOC.py) to retrieve the hash id associated to each safename.
+    Add columns of CDSE product ID and S3 path in a listing of products to download based on the safenames. This is useful for instance for the private data IOC products since the CDSE Odata search does not return the hash id for those products but only the safename. The method is using the same query method as the one used in the CDSE Odata search script (opensearch_private_data_IOC.py) to retrieve the hash id associated to each safename.
 
     Args:
         listing_path (str):
+        conf (dict): configuration of the lib cdsodatacli (used to know which unit is PRIVATE)
         display_tqdm (bool): True -> tqdm progress bar for each queries [optional, default=False]
         email (str): email of the CDSE account to use for queries [optional, default None -> use cdsodatacli default behavior]
         password (str): password of the CDSE account to use for queries [optional, default None -> use cdsodatacli default behavior]
 
     Returns:
-        res (pd.DataFrame): dataframe with 2 columns "id" and "safename" containing the hash id provided by CDSE Odata and the safename of the product
+        res (pd.DataFrame): dataframe with 3 columns "id", "safename", and "S3Path" containing the hash id provided by CDSE Odata and the safename of the product
 
     """
-    res = pd.DataFrame({"id": [], "safename": []})
+    res = pd.DataFrame({"id": [], "safename": [], "S3Path": []})
     df_raw = pd.read_csv(listing_path, names=["safenames"])
     df_raw = df_raw[df_raw["safenames"].str.contains(".SAFE")]
     list_safe_a = df_raw["safenames"].values
@@ -711,7 +722,8 @@ def add_missing_cdse_hash_ids_in_listing(
     # specific for private data IOC (S1D for instance)
     product_types = []
     for ii in range(len(list_safe_a)):
-        if list_safe_a[ii].startswith("S1D"):
+        # if list_safe_a[ii].startswith("S1D"):
+        if list_safe_a[0:3] in conf['list_sar_unit_private_data']:
             product_types.append(list_safe_a[ii][4:14] + "_PRIVATE")
 
         else:
@@ -752,9 +764,11 @@ def add_missing_cdse_hash_ids_in_listing(
             password=password,
         )
         if collected_data_norm is not None:
-            res = collected_data_norm[["Id", "Name"]]
+            res = collected_data_norm[["Id", "Name", "S3Path"]]
             res.rename(columns={"Name": "safename"}, inplace=True)
             res.rename(columns={"Id": "id"}, inplace=True)
+            assert 'S3Path' in res.columns, "S3Path column is missing in the result, check the fetch_data method"
+            
     return res
 
 
@@ -1155,8 +1169,7 @@ def download_list_product_multithread_v3(
 
 
 def download_list_product_multithread_v4(
-    list_id,
-    list_safename,
+    inputdf,
     outputdir,
     account_group,
     hideprogressbar=False,
@@ -1171,11 +1184,10 @@ def download_list_product_multithread_v4(
 
     Parameters
     ----------
-    list_id (list): list of satellite product hashs
-    list_safename (list): list of product names
+    inputdf (pd.DataFrame): DataFrame containing the products to download with columns "S3Path", "id", and "safename"
     outputdir (str): the directory where to store the product collected
     account_group (str): a group define in the config file with a unique account -> 4 sessions in parallel
-    hideProgressBar (bool): True -> no tqdm progress bar in stdout
+    hideprogressbar (bool): True -> no tqdm progress bar in stdout
     check_on_disk (bool): True -> if the product is in the spool dir or in archive dir the download is skipped
     cdsodatacli_conf_file (str): path to the cdsodatacli configuration file [ optional, default is None -> use cdsodatacli default behavior]
 
@@ -1183,21 +1195,25 @@ def download_list_product_multithread_v4(
     -------
         df2 (pd.DataFrame):
     """
-    assert len(list_id) == len(list_safename)
+    assert len(inputdf["S3Path"]) == len(inputdf["safename"])
+    if "status" not in inputdf.columns:
+        inputdf["status"] = np.zeros(len(inputdf["safename"]))
     logging.info("check_on_disk : %s", check_on_disk)
     cpt = defaultdict(int)
-    cpt["products_in_initial_listing"] = len(list_id)
+    cpt["products_in_initial_listing"] = len(inputdf["S3Path"])
     conf = get_conf(path_config_file=cdsodatacli_conf_file)
     if hideprogressbar:
         os.environ["DISABLE_TQDM"] = "True"
     all_speeds = []
+    all_elapsed_time = []
+    all_total_mb = []
     # status, 0->not treated, -1->error download , 1-> successful download
-    df = pd.DataFrame(
-        {"safe": list_safename, "status": np.zeros(len(list_safename)), "id": list_id}
-    )
+    # df = pd.DataFrame(
+    #     {"safe": list_safename, "status": np.zeros(len(list_safename)), "s3path": list_s3path}
+    # )
     force_download = not check_on_disk
     df2, cpt = filter_product_already_present(
-        cpt, df, outputdir, force_download=force_download, cdsodatacli_conf=conf
+        cpt, inputdf.rename(columns={'safename': 'safe'}), outputdir, force_download=force_download, cdsodatacli_conf=conf
     )
     t_start_download = time.time()
     logging.info("%s", cpt)
@@ -1215,7 +1231,6 @@ def download_list_product_multithread_v4(
         while (df2["status"] == 0).any():
 
             while_loop += 1
-
             subset_to_treat = df2[df2["status"] == 0]
             pbar.set_description(
                 f"loop={while_loop} | OK={cpt['successful_download']} | ERR={sum(v for k,v in cpt.items() if k.startswith('status_') and k != 'status_OK')} | todo={len(subset_to_treat)} | //={len(running_futures)}"
@@ -1229,7 +1244,6 @@ def download_list_product_multithread_v4(
             df_prod_downloadable = get_sessions_download_available(
                 conf,
                 subset_to_treat,
-                hideProgressBar=True,
                 blacklist=blacklist,
                 logins_group=account_group,
             )
@@ -1286,6 +1300,7 @@ def download_list_product_multithread_v4(
                 header = df_prod_downloadable["header"].loc[url_one_index]
                 url_product = df_prod_downloadable["url"].loc[url_one_index]
                 output_path = df_prod_downloadable["output_path"].loc[url_one_index]
+                s3path = df_prod_downloadable["S3Path"].loc[url_one_index]
                 # path_semaphore_token = df_prod_downloadable["token_semaphore"].loc[
                 #     url_one_index
                 # ]  # Added .loc
@@ -1298,12 +1313,10 @@ def download_list_product_multithread_v4(
                 #     url_one_index
                 # ]
                 future = executor.submit(
-                    CDS_Odata_download_one_product_v2,
-                    session,
+                    cds_s3_download_one_product,
+                    s3path,
                     header,
-                    url_product,
                     output_path,
-                    # path_semaphore_token,
                     conf=conf,
                 )
                 future_to_info[future] = {
@@ -1329,8 +1342,11 @@ def download_list_product_multithread_v4(
                 login_used = info.get("login", "unknown")
                 try:
                     # process result
+                    # speed,elapsed_time,total_mb, status_meaning, safename_base
                     (
                         speed,
+                        elapsed_time,
+                        total_mb,
                         status_meaning,
                         safename_base,
                         # semaphore_token_file,
@@ -1364,6 +1380,8 @@ def download_list_product_multithread_v4(
                 if status_meaning == "OK":
                     df2.loc[(df2["safe"] == safename_base), "status"] = 1
                     all_speeds.append(speed)
+                    all_elapsed_time.append(elapsed_time)
+                    all_total_mb.append(total_mb)
                     cpt["successful_download"] += 1
                 else:
                     df2.loc[(df2["safe"] == safename_base), "status"] = -1
@@ -1401,6 +1419,18 @@ def download_list_product_multithread_v4(
             "average download speed %1.1f Mo/s (stdev: %1.1f Mo/s)",
             np.mean(all_speeds),
             np.std(all_speeds),
+        )
+    if len(all_elapsed_time) > 0:
+        logging.info(
+            "average elapsed time %1.1f s (stdev: %1.1f s)",
+            np.mean(all_elapsed_time),
+            np.std(all_elapsed_time),
+        )
+    if len(all_total_mb) > 0:
+        logging.info(
+            "cumulated size %1.1f Go (average: %1.1f Go)",
+            np.sum(all_total_mb) / 1024,
+            np.mean(all_total_mb) / 1024,
         )
     return df2
 

--- a/cdsodatacli/download.py
+++ b/cdsodatacli/download.py
@@ -4,7 +4,6 @@ from tqdm import tqdm
 import datetime
 import time
 import os
-import boto3
 from botocore.exceptions import BotoCoreError, ClientError
 import warnings
 import traceback
@@ -171,7 +170,7 @@ def CDS_Odata_download_one_product_v2(
 
 
 def cds_s3_download_one_product(
-    s3_path,       
+    s3_path,
     header,
     output_filepath,
     conf,
@@ -180,7 +179,7 @@ def cds_s3_download_one_product(
     Download a single SAFE product via the CDSE S3 endpoint using boto3.
 
 
-    
+
     The conf dict must contain:
         - pre_spool   (str): temp directory for .tmp files
         - s3_access_key (str): CDSE S3 access key
@@ -206,7 +205,6 @@ def cds_s3_download_one_product(
         safename_base  (str): basename without .zip
     """
 
-
     speed = np.nan
     total_mb = 0
     status_meaning = "unknown"
@@ -216,9 +214,9 @@ def cds_s3_download_one_product(
     output_filepath_tmp = os.path.join(
         conf["pre_spool"], os.path.basename(output_filepath) + ".tmp"
     )
-    
+    s3_credentials = None
     try:
-        s3 = _get_fresh_s3_client(conf, headers=header)
+        s3_credentials, s3_resources = _get_fresh_s3_client(conf, headers=header)
         # s3 = boto3.resource(
         #     "s3",
         #     endpoint_url=conf["s3_endpoint"],
@@ -226,7 +224,7 @@ def cds_s3_download_one_product(
         #     aws_secret_access_key=conf["s3_secret_key"],
         #     region_name=conf.get("s3_region", "default"),
         # )
-        bucket = s3.Bucket(conf["s3_bucket"])
+        bucket = s3_resources.Bucket(conf["s3_bucket"])
 
         # List all objects under the SAFE prefix
         objects = list(bucket.objects.filter(Prefix=s3_path))
@@ -241,7 +239,10 @@ def cds_s3_download_one_product(
         # For a .SAFE folder (multi-file), download each file in place
         if len(objects) == 1:
             obj = objects[0]
-            logging.debug("Downloading single object %s -> %s", obj.key, output_filepath_tmp)
+            logging.info("object key: %s, size: %.1f Mo", obj.key, obj.size / 1e6)
+            logging.debug(
+                "Downloading single object %s -> %s", obj.key, output_filepath_tmp
+            )
             bucket.download_file(obj.key, output_filepath_tmp)
 
             elapsed_time = time.time() - t0
@@ -282,13 +283,26 @@ def cds_s3_download_one_product(
         elapsed_time = time.time() - t0
         if os.path.exists(output_filepath_tmp):
             os.remove(output_filepath_tmp)
+    if s3_credentials is not None:
+        # Delete the temporary S3 credentials
+        delete_response = requests.delete(
+            f"https://s3-keys-manager.cloudferro.com/api/user/credentials/access_id/{s3_credentials['access_id']}",
+            headers=header,
+        )
+        if delete_response.status_code == 204:
+            logger.debug("Temporary S3 credentials deleted successfully.")
+        else:
+            logger.error(
+                f"Failed to delete temporary S3 credentials. Status code: {delete_response.status_code}"
+            )
 
     logging.debug("time to download this product: %1.1f sec", elapsed_time)
     logging.debug("average download speed: %1.1f Mo/sec", speed)
-    return speed,elapsed_time,total_mb, status_meaning, safename_base
+    return speed, elapsed_time, total_mb, status_meaning, safename_base
+
 
 def filter_product_already_present(
-    cpt, df, outputdir, cdsodatacli_conf, force_download=False
+    cpt, df, outputdir, cdsodatacli_conf, force_download=False, extension=".zip"
 ):
     """
     Based on a dataframe of products to download, filter those already present locally.
@@ -301,6 +315,7 @@ def filter_product_already_present(
     outputdir (str)
     cdsodatacli_conf (dict): configuration dictionary of the lib cdsodatacli
     force_download (bool): True -> download all products even if already present locally [optional, default is False]
+    extension (str): file extension to check for presence on disk, default is ".zip" but can be ".SAFE" if products are already unzipped in the outputdir
 
 
     Returns
@@ -351,7 +366,7 @@ def filter_product_already_present(
                 )
                 all_urls_to_download.append(url_product)
 
-            output_filepath = os.path.join(outputdir, safename_product + ".zip")
+            output_filepath = os.path.join(outputdir, safename_product + extension)
             all_output_filepath.append(output_filepath)
 
     df_todownload = df.iloc[index_to_download]
@@ -671,7 +686,7 @@ def download_list_product(
     return cpt
 
 
-def test_listing_content(listing_path)->bool:
+def test_listing_content(listing_path) -> bool:
     """
     make sure that a listing of products to download respect the following format:
         cdse-hash-id,safename or s3-path,safename
@@ -691,7 +706,9 @@ def test_listing_content(listing_path)->bool:
         if "SAFE" in second_line.split(",")[1] and "S" in second_line.split(",")[1][0]:
             listing_OK = True
     # check that there is a header in the listing.
-    if "safename" in first_line.lower() and ("id" in first_line.lower() or "s3_path" in first_line.lower()):
+    if "safename" in first_line.lower() and (
+        "id" in first_line.lower() or "s3_path" in first_line.lower()
+    ):
         listing_OK = True
     return listing_OK
 
@@ -725,7 +742,7 @@ def add_missing_cdse_hash_ids_in_listing(
     product_types = []
     for ii in range(len(list_safe_a)):
         # if list_safe_a[ii].startswith("S1D"):
-        if list_safe_a[0:3] in conf['list_sar_unit_private_data']:
+        if list_safe_a[0:3] in conf["list_sar_unit_private_data"]:
             product_types.append(list_safe_a[ii][4:14] + "_PRIVATE")
 
         else:
@@ -769,8 +786,15 @@ def add_missing_cdse_hash_ids_in_listing(
             res = collected_data_norm[["Id", "Name", "S3Path"]]
             res.rename(columns={"Name": "safename"}, inplace=True)
             res.rename(columns={"Id": "id"}, inplace=True)
-            assert 'S3Path' in res.columns, "S3Path column is missing in the result, check the fetch_data method"
-            
+            # remove the /eodata/ at the begining of the S3Path.
+            res["S3Path"] = res["S3Path"].apply(lambda x: x.replace("/eodata/", ""))
+            assert (
+                "S3Path" in res.columns
+            ), "S3Path column is missing in the result, check the fetch_data method"
+            assert (
+                res["S3Path"].iloc[0].startswith("Sentinel-1/")
+            ), "S3Path column does not contain expected values, check the fetch_data method"
+
     return res
 
 
@@ -1134,7 +1158,7 @@ def download_list_product_multithread_v3(
                     df2.loc[(df2["safe"] == safename_base), "status"] = -1
                     errors_per_account[login_used] += 1
                     logger.info(
-                        "error found for %s meaning %s", login_used, status_meaning
+                        "error found for %s reason: %s", login_used, status_meaning
                     )
                     # df2["status"][df2["safe"] == safename_base] = -1 # download in error
                 # if retries[safename_base] > MAX_RETRIES:
@@ -1215,7 +1239,12 @@ def download_list_product_multithread_v4(
     # )
     force_download = not check_on_disk
     df2, cpt = filter_product_already_present(
-        cpt, inputdf.rename(columns={'safename': 'safe'}), outputdir, force_download=force_download, cdsodatacli_conf=conf
+        cpt,
+        inputdf.rename(columns={"safename": "safe"}),
+        outputdir,
+        force_download=force_download,
+        cdsodatacli_conf=conf,
+        extension="",
     )
     t_start_download = time.time()
     logging.info("%s", cpt)
@@ -1298,9 +1327,9 @@ def download_list_product_multithread_v4(
                 # output_path = df_prod_downloadable["output_path"].iloc[url_one_index]
 
                 # Corrected lines inside download_list_product_multithread_v3
-                session = df_prod_downloadable["session"].loc[url_one_index]
+                # session = df_prod_downloadable["session"].loc[url_one_index]
                 header = df_prod_downloadable["header"].loc[url_one_index]
-                url_product = df_prod_downloadable["url"].loc[url_one_index]
+                # url_product = df_prod_downloadable["url"].loc[url_one_index]
                 output_path = df_prod_downloadable["output_path"].loc[url_one_index]
                 s3path = df_prod_downloadable["S3Path"].loc[url_one_index]
                 # path_semaphore_token = df_prod_downloadable["token_semaphore"].loc[
@@ -1379,7 +1408,7 @@ def download_list_product_multithread_v4(
                 #     logging.error("traceback : %s", traceback.format_exc())
                 #     speed = np.nan
                 #     status_meaning = "DownloadError"
-                if status_meaning == "OK":
+                if status_meaning == "OK" or status_meaning == "Downloaded":
                     df2.loc[(df2["safe"] == safename_base), "status"] = 1
                     all_speeds.append(speed)
                     all_elapsed_time.append(elapsed_time)

--- a/cdsodatacli/fetch_access_token.py
+++ b/cdsodatacli/fetch_access_token.py
@@ -35,14 +35,27 @@ def get_bearer_access_token(
         login (str): account used
     """
     if specific_account is None:
-        login = random.choice(list(conf[account_group].keys()))
+        if isinstance(conf[account_group], list):
+            login = random.choice(
+                [list(d.keys())[0] for d in conf[account_group] if isinstance(d, dict)]
+            )
+        elif isinstance(conf[account_group], dict):
+            login = random.choice(list(conf[account_group].keys()))
+        else:
+            raise ValueError(f"Unexpected format for account group {account_group} in config file")
     else:
         login = specific_account
+
     if specific_psswd is None:
-        passwd = conf[account_group][login]
+        if isinstance(conf[account_group],list):
+            idx = next(i for i, d in enumerate(conf[account_group]) if login in d)
+            passwd = conf[account_group][idx][login]
+        elif isinstance(conf[account_group], dict):
+            passwd = conf[account_group][login]
+        else:
+            raise ValueError(f"Unexpected format for account group {account_group} in config file")
     else:
         passwd = specific_psswd
-
     # check if a valid token already exists in cache before hitting the server
     with _token_cache_lock:
         if login in ACTIVE_ACCESS_TOKEN:

--- a/cdsodatacli/fetch_access_token.py
+++ b/cdsodatacli/fetch_access_token.py
@@ -42,22 +42,31 @@ def get_bearer_access_token(
                 [list(d.keys())[0] for d in conf[account_group] if isinstance(d, dict)]
             )
         elif isinstance(conf[account_group], dict):
+
             login = random.choice(list(conf[account_group].keys()))
         else:
-            raise ValueError(f"Unexpected format for account group {account_group} in config file")
+            raise ValueError(
+                f"Unexpected format for account group {account_group} in config file"
+            )
     else:
         login = specific_account
 
     if specific_psswd is None:
-        if isinstance(conf[account_group],list):
+        if isinstance(conf[account_group], list):
             idx = next(i for i, d in enumerate(conf[account_group]) if login in d)
             passwd = conf[account_group][idx][login]
         elif isinstance(conf[account_group], dict):
             passwd = conf[account_group][login]
         else:
-            raise ValueError(f"Unexpected format for account group {account_group} in config file")
+            raise ValueError(
+                f"Unexpected format for account group {account_group} in config file"
+            )
     else:
         passwd = specific_psswd
+    logger.debug(
+        f"Requesting access token for account {login} from group {account_group}"
+    )
+    logger.debug(f"Password for {login} is {'*' * len(passwd) if passwd else '(none)'}")
     # check if a valid token already exists in cache before hitting the server
     with _token_cache_lock:
         if login in ACTIVE_ACCESS_TOKEN:

--- a/cdsodatacli/s3_temporary_access_token.py
+++ b/cdsodatacli/s3_temporary_access_token.py
@@ -1,0 +1,17 @@
+import boto3
+import requests
+def _get_fresh_s3_client(conf, headers):
+    """Always create a fresh boto3 client with new temporary credentials."""
+    creds_resp = requests.post(
+        "https://s3-keys-manager.cloudferro.com/api/user/credentials",
+        headers=headers
+    )
+    creds_resp.raise_for_status()
+    creds = creds_resp.json()
+    return boto3.resource(
+        "s3",
+        endpoint_url=conf.get("s3_endpoint", "https://eodata.dataspace.copernicus.eu"),
+        aws_access_key_id=creds["access_id"],
+        aws_secret_access_key=creds["secret"],
+        region_name=conf.get("s3_region", "default"),
+    )

--- a/cdsodatacli/s3_temporary_access_token.py
+++ b/cdsodatacli/s3_temporary_access_token.py
@@ -1,5 +1,8 @@
 import boto3
 import requests
+from cdsodatacli.fetch_access_token import get_bearer_access_token
+from cdsodatacli.utils import get_conf
+import logging
 def _get_fresh_s3_client(conf, headers):
     """Always create a fresh boto3 client with new temporary credentials."""
     creds_resp = requests.post(
@@ -15,3 +18,39 @@ def _get_fresh_s3_client(conf, headers):
         aws_secret_access_key=creds["secret"],
         region_name=conf.get("s3_region", "default"),
     )
+
+
+if __name__ == "__main__":
+    # Example usage
+    conf = {
+        "s3_endpoint": "https://eodata.dataspace.copernicus.eu",
+        "s3_region": "default",
+    }
+    import argparse
+    parser = argparse.ArgumentParser(description="Test S3 client with temporary access token")
+    parser.add_argument("--account", required=False, help="CDSE account to use for token retrieval")
+    parser.add_argument('--group', default='logins', help="Group in config file to select account from (default: 'logins')")
+    parser.add_argument('--cdsodatacli_conf_file', required=True,
+         help="path to the cdsodatacli configuration file .yml ")
+    parser.add_argument("--verbose", action="store_true", default=False, help="Enable verbose logging")
+    args = parser.parse_args()
+
+    fmt = "%(asctime)s %(levelname)s %(filename)s(%(lineno)d) %(message)s"
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format=fmt,
+        datefmt="%d/%m/%Y %H:%M:%S",
+        force=True,
+    )
+    account = args.account
+
+    conf = get_conf(path_config_file=args.cdsodatacli_conf_file)
+    token, date_generation, login = get_bearer_access_token(
+        conf, specific_account=account, specific_psswd=None, account_group=args.group
+        )
+    headers = {"Authorization": f"Bearer {token}"}
+    logging.info("Successfully retrieved temporary access token for account %s", account)
+    logging.debug("Token details: %s", {"token": token, "date_generation": date_generation, "login": login})
+    s3_client = _get_fresh_s3_client(conf, headers)
+    print("Successfully created S3 client with temporary credentials.")
+    print(s3_client)

--- a/cdsodatacli/s3_temporary_access_token.py
+++ b/cdsodatacli/s3_temporary_access_token.py
@@ -3,21 +3,33 @@ import requests
 from cdsodatacli.fetch_access_token import get_bearer_access_token
 from cdsodatacli.utils import get_conf
 import logging
+
+
 def _get_fresh_s3_client(conf, headers):
-    """Always create a fresh boto3 client with new temporary credentials."""
+    """
+    Create a S3 resources (boto3 client) and S3 temporary credentials.
+
+    Args:
+        conf (dict): Configuration dictionary containing S3 endpoint, region, and bucket information.
+        headers (dict): Headers containing the Bearer token for authentication.
+
+
+    Returns:
+        tuple: A tuple containing the S3 temporary credentials and the boto3 S3 resource object.
+    """
     creds_resp = requests.post(
-        "https://s3-keys-manager.cloudferro.com/api/user/credentials",
-        headers=headers
+        "https://s3-keys-manager.cloudferro.com/api/user/credentials", headers=headers
     )
     creds_resp.raise_for_status()
-    creds = creds_resp.json()
-    return boto3.resource(
+    s3_creds = creds_resp.json()
+    s3_resources = boto3.resource(
         "s3",
         endpoint_url=conf.get("s3_endpoint", "https://eodata.dataspace.copernicus.eu"),
-        aws_access_key_id=creds["access_id"],
-        aws_secret_access_key=creds["secret"],
+        aws_access_key_id=s3_creds["access_id"],
+        aws_secret_access_key=s3_creds["secret"],
         region_name=conf.get("s3_region", "default"),
     )
+    return s3_creds, s3_resources
 
 
 if __name__ == "__main__":
@@ -27,12 +39,26 @@ if __name__ == "__main__":
         "s3_region": "default",
     }
     import argparse
-    parser = argparse.ArgumentParser(description="Test S3 client with temporary access token")
-    parser.add_argument("--account", required=False, help="CDSE account to use for token retrieval")
-    parser.add_argument('--group', default='logins', help="Group in config file to select account from (default: 'logins')")
-    parser.add_argument('--cdsodatacli_conf_file', required=True,
-         help="path to the cdsodatacli configuration file .yml ")
-    parser.add_argument("--verbose", action="store_true", default=False, help="Enable verbose logging")
+
+    parser = argparse.ArgumentParser(
+        description="Test S3 client with temporary access token"
+    )
+    parser.add_argument(
+        "--account", required=False, help="CDSE account to use for token retrieval"
+    )
+    parser.add_argument(
+        "--group",
+        default="logins",
+        help="Group in config file to select account from (default: 'logins')",
+    )
+    parser.add_argument(
+        "--cdsodatacli_conf_file",
+        required=True,
+        help="path to the cdsodatacli configuration file .yml ",
+    )
+    parser.add_argument(
+        "--verbose", action="store_true", default=False, help="Enable verbose logging"
+    )
     args = parser.parse_args()
 
     fmt = "%(asctime)s %(levelname)s %(filename)s(%(lineno)d) %(message)s"
@@ -47,10 +73,29 @@ if __name__ == "__main__":
     conf = get_conf(path_config_file=args.cdsodatacli_conf_file)
     token, date_generation, login = get_bearer_access_token(
         conf, specific_account=account, specific_psswd=None, account_group=args.group
-        )
+    )
+    s3_creds = None
     headers = {"Authorization": f"Bearer {token}"}
-    logging.info("Successfully retrieved temporary access token for account %s", account)
-    logging.debug("Token details: %s", {"token": token, "date_generation": date_generation, "login": login})
-    s3_client = _get_fresh_s3_client(conf, headers)
+    logging.info(
+        "Successfully retrieved temporary access token for account %s", account
+    )
+    logging.debug(
+        "Token details: %s",
+        {"token": token, "date_generation": date_generation, "login": login},
+    )
+    s3_creds, s3_resources = _get_fresh_s3_client(conf, headers)
     print("Successfully created S3 client with temporary credentials.")
-    print(s3_client)
+    print(s3_creds)
+    print(s3_resources)
+    if s3_creds is not None:
+        # Delete the temporary S3 credentials
+        delete_response = requests.delete(
+            f"https://s3-keys-manager.cloudferro.com/api/user/credentials/access_id/{s3_creds['access_id']}",
+            headers=headers,
+        )
+        if delete_response.status_code == 204:
+            logging.info("Temporary S3 credentials deleted successfully.")
+        else:
+            logging.error(
+                f"Failed to delete temporary S3 credentials. Status code: {delete_response.status_code}"
+            )

--- a/cdsodatacli/scripts/download_multithread_one_account_deamon.py
+++ b/cdsodatacli/scripts/download_multithread_one_account_deamon.py
@@ -120,8 +120,7 @@ def entrypoint():
         if args.download_backend == "zipper":
             logging.info("Using zipper backend for download")
             dfout = download_list_product_multithread_v3(
-                list_id=inputdf["id"].values,
-                list_safename=inputdf["safename"].values,
+                inputdf=inputdf,
                 outputdir=outputdir,
                 hideprogressbar=False,
                 account_group=logins_group,

--- a/cdsodatacli/scripts/download_multithread_one_account_deamon.py
+++ b/cdsodatacli/scripts/download_multithread_one_account_deamon.py
@@ -76,8 +76,8 @@ def entrypoint():
     )
     parser.add_argument(
         "--download-backend",
-        choices=['zipper','s3endpoint'],
-        default='s3endpoint',
+        choices=["zipper", "s3endpoint"],
+        default="s3endpoint",
         help="backend to use for downloading products, 'zipper' will use the legacy zipper API, 's3endpoint' will use direct S3 endpoint access (default: 's3endpoint')",
     )
     args = parser.parse_args()
@@ -99,25 +99,25 @@ def entrypoint():
     conf = get_conf(path_config_file=args.cdsodatacli_conf_file)
     logins_group = args.logingroup
     logging.info(
-        "Number of account in  %s logins_group : %s",
+        "Number of account in  %s logins_group : %i",
         logins_group,
         len(conf[logins_group]),
     )
     outputdir = args.outputdir
-    if args.download_backend == 'zipper':
+    if args.download_backend == "zipper":
         first_var = "id"
     else:
         first_var = "S3Path"
     if test_listing_content(listing_path=listing):
-        
-        inputdf = pd.read_csv(listing, delimiter=",") # header is mandatory
+
+        inputdf = pd.read_csv(listing, delimiter=",")  # header is mandatory
     else:
-        inputdf = add_missing_cdse_hash_ids_in_listing(listing_path=listing,conf=conf)
+        inputdf = add_missing_cdse_hash_ids_in_listing(listing_path=listing, conf=conf)
     if not os.path.exists(outputdir):
         logging.debug("mkdir on %s", outputdir)
         os.makedirs(outputdir, 0o0775)
     if len(inputdf[first_var]) > 0:
-        if args.download_backend == 'zipper':
+        if args.download_backend == "zipper":
             logging.info("Using zipper backend for download")
             dfout = download_list_product_multithread_v3(
                 list_id=inputdf["id"].values,
@@ -129,9 +129,9 @@ def entrypoint():
                 cdsodatacli_conf_file=args.cdsodatacli_conf_file,
             )
         else:
-            logging.info("Using s3endpoint backend for download")   
+            logging.info("Using s3endpoint backend for download")
             dfout = download_list_product_multithread_v4(
-                inputdf=inputdf,#.rename(columns={'safename':'safe'}),
+                inputdf=inputdf,  # .rename(columns={'safename':'safe'}),
                 outputdir=outputdir,
                 hideprogressbar=False,
                 account_group=logins_group,

--- a/cdsodatacli/scripts/download_multithread_one_account_deamon.py
+++ b/cdsodatacli/scripts/download_multithread_one_account_deamon.py
@@ -13,6 +13,7 @@ import pandas as pd
 import cdsodatacli
 from cdsodatacli.download import (
     download_list_product_multithread_v3,
+    download_list_product_multithread_v4,
     test_listing_content,
     add_missing_cdse_hash_ids_in_listing,
 )
@@ -73,6 +74,12 @@ def entrypoint():
         default=None,
         help="path to the cdsodatacli configuration file .yml [optional, default is localconfig.yml then config.yml]",
     )
+    parser.add_argument(
+        "--download-backend",
+        choices=['zipper','s3endpoint'],
+        default='s3endpoint',
+        help="backend to use for downloading products, 'zipper' will use the legacy zipper API, 's3endpoint' will use direct S3 endpoint access (default: 's3endpoint')",
+    )
     args = parser.parse_args()
     fmt = "%(asctime)s %(levelname)s %(filename)s(%(lineno)d) %(message)s"
     if args.verbose:
@@ -97,24 +104,41 @@ def entrypoint():
         len(conf[logins_group]),
     )
     outputdir = args.outputdir
-    if test_listing_content(listing_path=listing):
-        inputdf = pd.read_csv(listing, names=["id", "safename"], delimiter=",")
+    if args.download_backend == 'zipper':
+        first_var = "id"
     else:
-        inputdf = add_missing_cdse_hash_ids_in_listing(listing_path=listing)
+        first_var = "S3Path"
+    if test_listing_content(listing_path=listing):
+        
+        inputdf = pd.read_csv(listing, delimiter=",") # header is mandatory
+    else:
+        inputdf = add_missing_cdse_hash_ids_in_listing(listing_path=listing,conf=conf)
     if not os.path.exists(outputdir):
         logging.debug("mkdir on %s", outputdir)
         os.makedirs(outputdir, 0o0775)
-    if len(inputdf["id"]) > 0:
-        dfout = download_list_product_multithread_v3(
-            list_id=inputdf["id"].values,
-            list_safename=inputdf["safename"].values,
-            outputdir=outputdir,
-            hideProgressBar=False,
-            account_group=logins_group,
-            check_on_disk=not args.forcedownload,
-            cdsodatacli_conf_file=args.cdsodatacli_conf_file,
-        )
-        logging.debug("downloaded dataframe: %s", dfout)
+    if len(inputdf[first_var]) > 0:
+        if args.download_backend == 'zipper':
+            logging.info("Using zipper backend for download")
+            dfout = download_list_product_multithread_v3(
+                list_id=inputdf["id"].values,
+                list_safename=inputdf["safename"].values,
+                outputdir=outputdir,
+                hideprogressbar=False,
+                account_group=logins_group,
+                check_on_disk=not args.forcedownload,
+                cdsodatacli_conf_file=args.cdsodatacli_conf_file,
+            )
+        else:
+            logging.info("Using s3endpoint backend for download")   
+            dfout = download_list_product_multithread_v4(
+                inputdf=inputdf,#.rename(columns={'safename':'safe'}),
+                outputdir=outputdir,
+                hideprogressbar=False,
+                account_group=logins_group,
+                check_on_disk=not args.forcedownload,
+                cdsodatacli_conf_file=args.cdsodatacli_conf_file,
+            )
+            logging.debug("downloaded dataframe: %s", dfout)
     else:
         logging.info("empty listing to treat")
     logging.info("end of function")

--- a/cdsodatacli/scripts/get_ids_listing_safe_iterative.py
+++ b/cdsodatacli/scripts/get_ids_listing_safe_iterative.py
@@ -2,6 +2,7 @@ import numpy as np
 import logging
 
 import cdsodatacli.download as dl
+from cdsodatacli.utils import get_conf
 import pandas as pd
 import tempfile
 
@@ -18,11 +19,13 @@ def entrypoint():
         logging.info(
             "No email/password provided, using cdsodatacli default behavior for authentication."
         )
+    conf = get_conf(args.cdsodatacli_conf_file)
     add_ids_to_listing_iterative(
         input_listing=args.input_listing,
         output_listing=args.output_listing,
         email=args.email,
         password=args.password,
+        conf=conf,
     )
 
 
@@ -100,7 +103,7 @@ def entrypoint():
 
 
 def add_ids_to_listing_iterative(
-    input_listing, output_listing=None, email=None, password=None
+    input_listing, output_listing=None, email=None, password=None, conf=None
 ):
     """
     This method aim as a wrapper for add_missing_cdse_hash_ids_in_listing(),
@@ -112,6 +115,7 @@ def add_ids_to_listing_iterative(
     :param output_listing: str where to store SAFE+ID [optional, default is input_listing+'.ids']
     :param email: str email of the CDSE account to use for queries [optional, default None -> use cdsodatacli default behavior]
     :param password: str password of the CDSE account to use for queries [optional, default None -> use cdsodatacli default behavior]
+    :param conf: dict configuration of the lib cdsodatacli [optional, default None -> use cdsodatacli default behavior]
 
     Return:
         output_listing: str: listing containing lines SAFE+ID
@@ -151,7 +155,7 @@ def add_ids_to_listing_iterative(
 
         # Appel à l'API via cdsodatacli
         dfres = dl.add_missing_cdse_hash_ids_in_listing(
-            listing_path=tmplisting, display_tqdm=True, email=email, password=password
+            listing_path=tmplisting, display_tqdm=True, email=email, password=password, conf=conf
         )
 
         # --- CORRECTION ICI ---
@@ -265,6 +269,12 @@ def parse_args():
         required=False,
         default=None,
         help="password of the CDSE account to use for queries [optional, default None -> use cdsodatacli default behavior]",
+    )
+    parser.add_argument(
+        "--cdsodatacli_conf_file",
+        required=True,
+        default=None,
+        help="path to the cdsodatacli configuration file .yml",
     )
 
     args = parser.parse_args()

--- a/cdsodatacli/scripts/get_ids_listing_safe_iterative.py
+++ b/cdsodatacli/scripts/get_ids_listing_safe_iterative.py
@@ -155,7 +155,11 @@ def add_ids_to_listing_iterative(
 
         # Appel à l'API via cdsodatacli
         dfres = dl.add_missing_cdse_hash_ids_in_listing(
-            listing_path=tmplisting, display_tqdm=True, email=email, password=password, conf=conf
+            listing_path=tmplisting,
+            display_tqdm=True,
+            email=email,
+            password=password,
+            conf=conf,
         )
 
         # --- CORRECTION ICI ---

--- a/cdsodatacli/session.py
+++ b/cdsodatacli/session.py
@@ -131,7 +131,7 @@ def remove_semaphore_session_file(session_dir, safename=None, login=None):
 
 
 def get_sessions_download_available(
-    conf, subset_to_treat, hideProgressBar=True, blacklist=None, logins_group="logins"
+    conf, subset_to_treat, blacklist=None, logins_group="logins"
 ):
     """
 
@@ -139,7 +139,6 @@ def get_sessions_download_available(
     ----------
     conf (dict) configuration dictionary of cdsodatacli package
     subset_to_treat (pandas.DatFrame)
-    hideProgressBar (bool)
     blacklist (list): list of account not usable [default=None]
     logins_group (str): logins or loginsbackfill (for instance, it depends on the localconfig.yml)
     Returns
@@ -156,6 +155,7 @@ def get_sessions_download_available(
     all_safe_basename = []
     bunch_product_downloadable = []
     bunch_urls_to_download = []
+    bunch_s3path_to_download = []
     outputfiles_download_coming = []
 
     lst_sessions_active = get_list_active_session(conf, login_group=logins_group)
@@ -204,6 +204,7 @@ def get_sessions_download_available(
             if access_token is not None:
                 bunch_product_downloadable.append(safename_product)
                 bunch_urls_to_download.append(subset_to_treat["urls"].iloc[ss])
+                bunch_s3path_to_download.append(subset_to_treat['S3path'].iloc[ss])
                 outputfiles_download_coming.append(
                     subset_to_treat["outputpath"].iloc[ss]
                 )
@@ -228,6 +229,7 @@ def get_sessions_download_available(
     # df_products_downloadable["token_semaphore"] = all_semaphores
     df_products_downloadable["login"] = all_logins
     df_products_downloadable["url"] = bunch_urls_to_download
+    df_products_downloadable["S3path"] = bunch_s3path_to_download # to check S3path
     df_products_downloadable["output_path"] = outputfiles_download_coming
     df_products_downloadable["session_semaphore"] = all_session_semaphores
     df_products_downloadable["safe"] = all_safe_basename

--- a/cdsodatacli/session.py
+++ b/cdsodatacli/session.py
@@ -164,7 +164,14 @@ def get_sessions_download_available(
     # account_free = None
     account_counter = defaultdict(int)
     for aa in conf[logins_group]:
-        account_tmp = list(aa)[0]
+        if isinstance(aa, str):
+            account_tmp = aa
+        elif isinstance(aa, dict):
+            account_tmp = list(aa)[0]
+        else:
+            raise ValueError(
+                f"Unexpected format for account {aa} in group {logins_group}"
+            )
         account_counter[account_tmp] = 0
     logging.debug("(re)init the counts for accounts.")
     for toto in lst_sessions_active:
@@ -202,7 +209,6 @@ def get_sessions_download_available(
                     specific_account=account_free,
                     account_group=logins_group,
                 )
-         
 
             # else:  # select randomly one token among existing
             #     path_semphore_token = random.choice(lst_usable_tokens)
@@ -210,7 +216,7 @@ def get_sessions_download_available(
             if access_token is not None:
                 bunch_product_downloadable.append(safename_product)
                 bunch_urls_to_download.append(subset_to_treat["urls"].iloc[ss])
-                bunch_s3path_to_download.append(subset_to_treat['S3Path'].iloc[ss])
+                bunch_s3path_to_download.append(subset_to_treat["S3Path"].iloc[ss])
                 outputfiles_download_coming.append(
                     subset_to_treat["outputpath"].iloc[ss]
                 )
@@ -235,7 +241,7 @@ def get_sessions_download_available(
     # df_products_downloadable["token_semaphore"] = all_semaphores
     df_products_downloadable["login"] = all_logins
     df_products_downloadable["url"] = bunch_urls_to_download
-    df_products_downloadable["S3Path"] = bunch_s3path_to_download # to check S3path
+    df_products_downloadable["S3Path"] = bunch_s3path_to_download  # to check S3path
     df_products_downloadable["output_path"] = outputfiles_download_coming
     df_products_downloadable["session_semaphore"] = all_session_semaphores
     df_products_downloadable["safe"] = all_safe_basename

--- a/cdsodatacli/session.py
+++ b/cdsodatacli/session.py
@@ -140,7 +140,9 @@ def get_sessions_download_available(
     conf (dict) configuration dictionary of cdsodatacli package
     subset_to_treat (pandas.DatFrame)
     blacklist (list): list of account not usable [default=None]
-    logins_group (str): logins or loginsbackfill (for instance, it depends on the localconfig.yml)
+    logins_group (str): name of the group of CDSE accounts to use (can contain multiple accounts, it depends on the localconfig.yml)
+
+
     Returns
     -------
 
@@ -162,7 +164,8 @@ def get_sessions_download_available(
     # account_free = None
     account_counter = defaultdict(int)
     for aa in conf[logins_group]:
-        account_counter[aa] = 0
+        account_tmp = list(aa)[0]
+        account_counter[account_tmp] = 0
     logging.debug("(re)init the counts for accounts.")
     for toto in lst_sessions_active:
         account = os.path.basename(toto).split("_")[3]
@@ -181,6 +184,7 @@ def get_sessions_download_available(
             # lst_usable_tokens = get_list_of_existing_token_semaphore_file(
             #     token_dir=conf["token_directory"], account=account_free
             # )
+
             access_token, date_generation_access_token = get_valid_access_token(
                 login=account_free
             )
@@ -198,13 +202,15 @@ def get_sessions_download_available(
                     specific_account=account_free,
                     account_group=logins_group,
                 )
+         
+
             # else:  # select randomly one token among existing
             #     path_semphore_token = random.choice(lst_usable_tokens)
             #     access_token = open(path_semphore_token).readlines()[0]
             if access_token is not None:
                 bunch_product_downloadable.append(safename_product)
                 bunch_urls_to_download.append(subset_to_treat["urls"].iloc[ss])
-                bunch_s3path_to_download.append(subset_to_treat['S3path'].iloc[ss])
+                bunch_s3path_to_download.append(subset_to_treat['S3Path'].iloc[ss])
                 outputfiles_download_coming.append(
                     subset_to_treat["outputpath"].iloc[ss]
                 )
@@ -229,7 +235,7 @@ def get_sessions_download_available(
     # df_products_downloadable["token_semaphore"] = all_semaphores
     df_products_downloadable["login"] = all_logins
     df_products_downloadable["url"] = bunch_urls_to_download
-    df_products_downloadable["S3path"] = bunch_s3path_to_download # to check S3path
+    df_products_downloadable["S3Path"] = bunch_s3path_to_download # to check S3path
     df_products_downloadable["output_path"] = outputfiles_download_coming
     df_products_downloadable["session_semaphore"] = all_session_semaphores
     df_products_downloadable["safe"] = all_safe_basename

--- a/ci/requirements/docs.yaml
+++ b/ci/requirements/docs.yaml
@@ -6,4 +6,4 @@ dependencies:
   - sphinx>=4
   - sphinx_book_theme
   - ipython
-  - sphinx_rtd_theme
+  - sphinx-rtd-theme

--- a/ci/requirements/docs.yaml
+++ b/ci/requirements/docs.yaml
@@ -6,3 +6,4 @@ dependencies:
   - sphinx>=4
   - sphinx_book_theme
   - ipython
+  - sphinx_rtd_theme

--- a/ci/requirements/docs.yaml
+++ b/ci/requirements/docs.yaml
@@ -4,6 +4,5 @@ channels:
 dependencies:
   - python=3.11
   - sphinx>=4
-  - sphinx_book_theme
   - ipython
   - sphinx-rtd-theme

--- a/ci/requirements/docs.yaml
+++ b/ci/requirements/docs.yaml
@@ -6,3 +6,4 @@ dependencies:
   - sphinx>=4
   - ipython
   - sphinx-rtd-theme
+  - nbsphinx

--- a/ci/requirements/docs.yaml
+++ b/ci/requirements/docs.yaml
@@ -7,3 +7,4 @@ dependencies:
   - ipython
   - sphinx-rtd-theme
   - nbsphinx
+  - jupyter_sphinx

--- a/ci/requirements/environment.yaml
+++ b/ci/requirements/environment.yaml
@@ -20,3 +20,4 @@ dependencies:
   - pyyaml
   - cartopy
   - python-dotenv
+  - boto3

--- a/docs/basic_api.rst
+++ b/docs/basic_api.rst
@@ -15,4 +15,13 @@ methods descriptions
     :members: fetch_data
 
 .. automodule:: cdsodatacli.download
-    :members: download_list_product_sequential, download_list_product
+    :members: download_list_product_sequential, download_list_product, download_list_product_multithread_v4
+
+.. automodule:: cdsodatacli.utils
+    :members: get_conf, check_safe_in_outputdir, check_safe_in_spool, WhichArchiveDir, check_safe_in_archive, convert_json_opensearch_query_to_listing_safe_4_dowload, convert_json_odata_query_to_listing_safe_4_download
+
+.. automodule:: cdsodatacli.sessions
+    :members: get_list_active_session, get_a_free_account, write_active_session_semphore_file, remove_semaphore_session_file, get_sessions_download_available
+
+.. automodule:: cdsodatacli.s3_temporary_access_token
+    :members: _get_fresh_s3_client

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,7 @@
 import cdsodatacli
 
 project = "cdsodatacli"
-copyright = "2023, Ifremer LOPS/SIAM"
+copyright = "2026, Ifremer LOPS/SIAM"
 author = "Jean Renaud Miadana, Antoine Grouazel"
 version = cdsodatacli.__version__
 # root_doc='ATBD' # defaut 'index'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,8 +2,8 @@
 CDS OData Client
 ################
 
- - Copernicus Data Space Python client for OData API.
- - **cdsodatacli** is a  Python library to browse available Sentinel products on Copernicus Data Space platform.
+ - Copernicus Data Space Python client for OData API, to search and download Earth Observation products.
+ - **cdsodatacli** is a Python library to browse available Sentinel products on Copernicus Data Space platform.
 
 
 Documentation
@@ -12,7 +12,7 @@ Documentation
 Overview
 ........
 
- - Library mostly build on **geopandas** and **requests**.
+ - Library mostly build on OData API for search queries and S3 endpoint for download.
 
 
  - API used to perform queries is : https://documentation.dataspace.copernicus.eu/APIs/OData.html

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -34,13 +34,52 @@ For a download with a given login/password, you can use the command line tool `d
 
 2. Multi-threaded download with multiple users/accounts
 -------------------------------------------------------
-For a multi-threaded download with multiple users/accounts, you can use the command line tool `downloadMuliThreadMultiUser`:
+For a multi-threaded download with multiple users/accounts, you can use the command line tool `downloadMultiThreadMultiUserV3`:
 
 .. code-block:: bash
 
-    downloadMuliThreadMultiUser -h
+    downloadMultiThreadMultiUserV3 -h
+        usage: downloadMultiThreadMultiUserV3 [-h] [--verbose] [--forcedownload] [--logingroup LOGINGROUP] [--listing LISTING] --outputdir OUTPUTDIR [--cdsodatacli_conf_file CDSODATACLI_CONF_FILE]
+                                            [--download-backend {zipper,s3endpoint}]
+
+        download deamon CDSE
+
+        options:
+        -h, --help            show this help message and exit
+        --verbose
+        --forcedownload       True -> no test of existence of the products in spool and archive directories.
+        --logingroup LOGINGROUP
+                                name of the group of CDSE account in the localconfig.yml [default=logins]
+        --listing LISTING     path of the listing of products to download containing (Id,safename) lines
+        --outputdir OUTPUTDIR
+                                pathwhere product will be stored
+        --cdsodatacli_conf_file CDSODATACLI_CONF_FILE
+                                path to the cdsodatacli configuration file .yml [optional, default is localconfig.yml then config.yml]
+        --download-backend {zipper,s3endpoint}
+                                backend to use for downloading products, 'zipper' will use the legacy zipper API, 's3endpoint' will use direct S3 endpoint access (default: 's3endpoint')
 
 
+There are two download backends: "zipper" or "s3endpoint" available through `cdsodatacli`.
+The "s3endpoint" download backend is strongly recommended, it gives download speed up to 32 Mo/s while "zipper" is closer to
+
+Here is a table of download speed to compare the 2 backends, on tests performed in 2026:
+
++------------+------------+--------------------------------------+---------------------------+
+|            | backend    | average download speed (Mo/s)        | total duration (seconds)  |
++============+============+======================================+===========================+
+| 2 IW OCN   | s3endpoint | 10.4 Mo/s (stdev: 0.5 Mo/s)          | 10.0                      |
++------------+------------+--------------------------------------+---------------------------+
+| 3 IW SLC   | s3endpoint | 32.1 Mo/s (stdev: 15.1 Mo/s)         | 524.287501                |
++------------+------------+--------------------------------------+---------------------------+
+| 2 IW OCN   | zipper     | 5.9 Mo/s (stdev: 1.3 Mo/s)           | 23.04                     |
++------------+------------+--------------------------------------+---------------------------+
+| 3 IW SLC   | zipper     | 4.2 Mo/s (stdev: 2.5 Mo/s)           | 2896.931142               |
++------------+------------+--------------------------------------+---------------------------+
+
+.. note::
+    5X faster downloads for S3!
+
+In addition, with "s3endpoint" backend, the products are already uncompressed at the end of the download.
 
 Get CDSE Odata IDs for a list of products
 =========================================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
   'pyyaml',
   'cartopy',
   "python-dotenv",
+  'boto3',
 ]
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ tqdm
 pyyaml
 cartopy
 python-dotenv
+boto3

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -125,8 +125,11 @@ def test_add_missing_cdse_hash_ids_in_listing(tmp_path, mock_conf):
     mock_exploded.product = "GRDH"
 
     mock_query_result = pd.DataFrame(
-        {"Id": ["uuid-123"], "Name": ["S1A_IW_GRDH_1SDV_20220503T000000.SAFE"],
-         "S3Path": ["Sentinel-1/SAR/GRD/S1A_IW_GRDH_1SDV_20220503T000000.SAFE"]}
+        {
+            "Id": ["uuid-123"],
+            "Name": ["S1A_IW_GRDH_1SDV_20220503T000000.SAFE"],
+            "S3Path": ["Sentinel-1/SAR/GRD/S1A_IW_GRDH_1SDV_20220503T000000.SAFE"],
+        }
     )
 
     with (
@@ -220,10 +223,19 @@ def test_download_list_product_multithread_v2(
     ):
 
         mock_filter.return_value = (
-            pd.DataFrame({"safe": ["SAFE1"], "status": [0], "id": ["id1"],
-                          "S3Path": ["Sentinel-1/SAR/GRD/S1A_IW_GRDH_1SDV_20220503T000000.SAFE"],
-                            "output_path": ["/tmp/SAFE1.zip"], "header": [{}],
-                              "url": ["url1"]}),
+            pd.DataFrame(
+                {
+                    "safe": ["SAFE1"],
+                    "status": [0],
+                    "id": ["id1"],
+                    "S3Path": [
+                        "Sentinel-1/SAR/GRD/S1A_IW_GRDH_1SDV_20220503T000000.SAFE"
+                    ],
+                    "output_path": ["/tmp/SAFE1.zip"],
+                    "header": [{}],
+                    "url": ["url1"],
+                }
+            ),
             defaultdict(int),
         )
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -114,7 +114,7 @@ def test_CDS_Odata_download_one_product_v2_success(
 
 
 # 3. Test Metadata generation
-def test_add_missing_cdse_hash_ids_in_listing(tmp_path,mock_conf):
+def test_add_missing_cdse_hash_ids_in_listing(tmp_path, mock_conf):
     listing = tmp_path / "list.txt"
     listing.write_text("S1A_IW_GRDH_1SDV_20220503T000000.SAFE")
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -20,6 +20,7 @@ def mock_conf():
         "active_session_directory": "/tmp/sessions",
         "logins": [{"user1@email.fr": "passwd1"}],
         "default_login": {"user1@email.fr": "passwd1"},
+        "list_sar_unit_private_data": ["S1D"],
     }
 
 
@@ -113,7 +114,7 @@ def test_CDS_Odata_download_one_product_v2_success(
 
 
 # 3. Test Metadata generation
-def test_add_missing_cdse_hash_ids_in_listing(tmp_path):
+def test_add_missing_cdse_hash_ids_in_listing(tmp_path,mock_conf):
     listing = tmp_path / "list.txt"
     listing.write_text("S1A_IW_GRDH_1SDV_20220503T000000.SAFE")
 
@@ -132,7 +133,7 @@ def test_add_missing_cdse_hash_ids_in_listing(tmp_path):
         patch("cdsodatacli.download.fetch_data", return_value=mock_query_result),
     ):
 
-        res = dl.add_missing_cdse_hash_ids_in_listing(str(listing))
+        res = dl.add_missing_cdse_hash_ids_in_listing(str(listing), mock_conf)
         assert not res.empty
         assert res["id"].iloc[0] == "uuid-123"
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -125,7 +125,8 @@ def test_add_missing_cdse_hash_ids_in_listing(tmp_path, mock_conf):
     mock_exploded.product = "GRDH"
 
     mock_query_result = pd.DataFrame(
-        {"Id": ["uuid-123"], "Name": ["S1A_IW_GRDH_1SDV_20220503T000000.SAFE"]}
+        {"Id": ["uuid-123"], "Name": ["S1A_IW_GRDH_1SDV_20220503T000000.SAFE"],
+         "S3Path": ["Sentinel-1/SAR/GRD/S1A_IW_GRDH_1SDV_20220503T000000.SAFE"]}
     )
 
     with (
@@ -219,7 +220,10 @@ def test_download_list_product_multithread_v2(
     ):
 
         mock_filter.return_value = (
-            pd.DataFrame({"safe": ["SAFE1"], "status": [0], "id": ["id1"]}),
+            pd.DataFrame({"safe": ["SAFE1"], "status": [0], "id": ["id1"],
+                          "S3Path": ["Sentinel-1/SAR/GRD/S1A_IW_GRDH_1SDV_20220503T000000.SAFE"],
+                            "output_path": ["/tmp/SAFE1.zip"], "header": [{}],
+                              "url": ["url1"]}),
             defaultdict(int),
         )
 

--- a/tests/test_download_list_multithread_v3.py
+++ b/tests/test_download_list_multithread_v3.py
@@ -51,11 +51,13 @@ def make_inputdf(safenames, ids=None, statuses=None):
         ids = [f"id-{i}" for i in range(n)]
     if statuses is None:
         statuses = np.zeros(n)
-    return pd.DataFrame({
-        "safename": safenames,
-        "id": ids,
-        "status": statuses,
-    })
+    return pd.DataFrame(
+        {
+            "safename": safenames,
+            "id": ids,
+            "status": statuses,
+        }
+    )
 
 
 def make_future_result(safename, status="OK", speed=10.0):
@@ -66,31 +68,36 @@ def make_future_result(safename, status="OK", speed=10.0):
 def make_df2(safenames):
     """Build a minimal df2 as filter_product_already_present would return."""
     n = len(safenames)
-    return pd.DataFrame({
-        "safe": safenames,
-        "status": np.zeros(n),
-        "id": [f"id-{i}" for i in range(n)],
-        "login": FAKE_LOGIN,
-        "outputpath": [f"/fake/out/{s}.zip" for s in safenames],
-    })
+    return pd.DataFrame(
+        {
+            "safe": safenames,
+            "status": np.zeros(n),
+            "id": [f"id-{i}" for i in range(n)],
+            "login": FAKE_LOGIN,
+            "outputpath": [f"/fake/out/{s}.zip" for s in safenames],
+        }
+    )
 
 
 def make_downloadable_df(safenames):
     """Simulate the output of get_sessions_download_available."""
     n = len(safenames)
-    return pd.DataFrame({
-        "safe": safenames,
-        "session": [MagicMock() for _ in range(n)],
-        "header": [{"Authorization": "Bearer tok"} for _ in range(n)],
-        "url": [f"https://fake.cdse/{s}" for s in safenames],
-        "login": FAKE_LOGIN,
-        "output_path": [f"/fake/out/{s}.zip" for s in safenames],
-    })
+    return pd.DataFrame(
+        {
+            "safe": safenames,
+            "session": [MagicMock() for _ in range(n)],
+            "header": [{"Authorization": "Bearer tok"} for _ in range(n)],
+            "url": [f"https://fake.cdse/{s}" for s in safenames],
+            "login": FAKE_LOGIN,
+            "output_path": [f"/fake/out/{s}.zip" for s in safenames],
+        }
+    )
 
 
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture(autouse=True)
 def patch_conf():
@@ -197,10 +204,12 @@ class TestInputValidation:
     def test_mismatched_safe_id_lengths_raise(self):
         """inputdf missing required column triggers KeyError/AssertionError
         before any network call is made."""
-        df = pd.DataFrame({
-            "safename": ["SAFE_A", "SAFE_B"],
-            # "id" intentionally absent — function must raise before network calls
-        })
+        df = pd.DataFrame(
+            {
+                "safename": ["SAFE_A", "SAFE_B"],
+                # "id" intentionally absent — function must raise before network calls
+            }
+        )
         with pytest.raises((AssertionError, KeyError)):
             download_list_product_multithread_v3(
                 inputdf=df,
@@ -210,14 +219,17 @@ class TestInputValidation:
 
     def test_status_column_created_if_absent(self, patch_filter):
         """If inputdf has no 'status' column, v3 must add it silently."""
-        df = pd.DataFrame({
-            "safename": ["SAFE_A"],
-            "id": ["id0"],
-            # no 'status' column
-        })
+        df = pd.DataFrame(
+            {
+                "safename": ["SAFE_A"],
+                "id": ["id0"],
+                # no 'status' column
+            }
+        )
 
-        def _all_done(cpt, df_in, outputdir, force_download, cdsodatacli_conf,
-                      **kwargs):
+        def _all_done(
+            cpt, df_in, outputdir, force_download, cdsodatacli_conf, **kwargs
+        ):
             empty = df_in.iloc[:0].copy()
             return empty, cpt
 
@@ -246,8 +258,9 @@ class TestDownloadError:
         def worker_side_effect(session, header, url, output_path, **kw):
             safename = os.path.basename(output_path).replace(".zip", "")
             if safename == "SAFE_FAIL":
-                return make_future_result("SAFE_FAIL", status="Unauthorized",
-                                          speed=np.nan)
+                return make_future_result(
+                    "SAFE_FAIL", status="Unauthorized", speed=np.nan
+                )
             return make_future_result(safename)
 
         with (
@@ -363,8 +376,9 @@ class TestAllAlreadyPresent:
     """All products already on disk — nothing to download."""
 
     def test_empty_df2_returns_immediately(self, patch_filter):
-        def _all_archived(cpt, df, outputdir, force_download, cdsodatacli_conf,
-                           **kwargs):
+        def _all_archived(
+            cpt, df, outputdir, force_download, cdsodatacli_conf, **kwargs
+        ):
             cpt["archived_product"] = len(df)
             empty = pd.DataFrame({"safe": [], "status": [], "id": []})
             return empty, cpt
@@ -443,6 +457,7 @@ class TestRaceCondition:
         def _release():
             time.sleep(0.2)
             barrier.set()
+
         threading.Thread(target=_release, daemon=True).start()
 
         def slow_worker(session, header, url, output_path, **kw):

--- a/tests/test_download_list_multithread_v3.py
+++ b/tests/test_download_list_multithread_v3.py
@@ -1,6 +1,16 @@
 """
 pytest unit tests for download_list_product_multithread_v3
 run with: pytest test_download_multithread_v3.py -v
+
+Signature updated to:
+    download_list_product_multithread_v3(
+        inputdf,
+        outputdir,
+        account_group,
+        hideprogressbar=False,
+        check_on_disk=True,
+        cdsodatacli_conf_file=None,
+    )
 """
 
 import os
@@ -28,11 +38,24 @@ FAKE_CONF = {
     },
 }
 
-# Format: CDSE_access_token_<login>_<date>.txt
-# split("_") -> [0]=CDSE [1]=access [2]=token [3]=login [4]=date.txt
 FAKE_LOGIN = "user@example.com"
-FAKE_DATE_STR = "20240101t120000"
-# FAKE_SEMAPHORE = f"/fake/token_dir/CDSE_access_token_{FAKE_LOGIN}_{FAKE_DATE_STR}.txt"
+
+
+def make_inputdf(safenames, ids=None, statuses=None):
+    """Build a minimal inputdf as download_list_product_multithread_v3 now expects.
+    Uses 'safename' column — v3 (like v4) accepts 'safename' and renames to 'safe'
+    internally before passing to filter_product_already_present.
+    """
+    n = len(safenames)
+    if ids is None:
+        ids = [f"id-{i}" for i in range(n)]
+    if statuses is None:
+        statuses = np.zeros(n)
+    return pd.DataFrame({
+        "safename": safenames,
+        "id": ids,
+        "status": statuses,
+    })
 
 
 def make_future_result(safename, status="OK", speed=10.0):
@@ -40,65 +63,51 @@ def make_future_result(safename, status="OK", speed=10.0):
     return (speed, status, safename)
 
 
-# def make_future_result(s):
-#     # The 3rd value must be the string 's'
-#     return (1.0, "OK", s, FAKE_SEMAPHORE)
-
-
 def make_df2(safenames):
     """Build a minimal df2 as filter_product_already_present would return."""
     n = len(safenames)
-    df = pd.DataFrame(
-        {
-            "safe": safenames,
-            "status": np.zeros(n),
-            "id": [f"id-{i}" for i in range(n)],
-            "login": FAKE_LOGIN,
-            "outputpath": [f"/fake/out/{s}.zip" for s in safenames],
-        }
-    )
-    return df
+    return pd.DataFrame({
+        "safe": safenames,
+        "status": np.zeros(n),
+        "id": [f"id-{i}" for i in range(n)],
+        "login": FAKE_LOGIN,
+        "outputpath": [f"/fake/out/{s}.zip" for s in safenames],
+    })
 
 
 def make_downloadable_df(safenames):
     """Simulate the output of get_sessions_download_available."""
     n = len(safenames)
-    sessions = [MagicMock() for _ in range(n)]
-    df = pd.DataFrame(
-        {
-            "safe": safenames,
-            "session": sessions,
-            "header": [{"Authorization": "Bearer tok"} for _ in range(n)],
-            "url": [f"https://fake.cdse/{s}" for s in safenames],
-            "login": FAKE_LOGIN,
-            "output_path": [f"/fake/out/{s}.zip" for s in safenames],
-            # "token_semaphore": [FAKE_SEMAPHORE for _ in range(n)],
-        }
-    )
-    return df
+    return pd.DataFrame({
+        "safe": safenames,
+        "session": [MagicMock() for _ in range(n)],
+        "header": [{"Authorization": "Bearer tok"} for _ in range(n)],
+        "url": [f"https://fake.cdse/{s}" for s in safenames],
+        "login": FAKE_LOGIN,
+        "output_path": [f"/fake/out/{s}.zip" for s in safenames],
+    })
 
 
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
 
-
 @pytest.fixture(autouse=True)
-def patch_conf(monkeypatch):
+def patch_conf():
     """Always return FAKE_CONF from get_conf."""
     with patch("cdsodatacli.download.get_conf", return_value=FAKE_CONF):
         yield
 
 
 @pytest.fixture(autouse=True)
-def patch_filter(monkeypatch):
+def patch_filter():
     """
     By default filter_product_already_present returns all products as
     to-download (status=0).  Individual tests can override this.
     """
     with patch("cdsodatacli.download.filter_product_already_present") as mock:
 
-        def _default(cpt, df, outputdir, force_download, cdsodatacli_conf):
+        def _default(cpt, df, outputdir, force_download, cdsodatacli_conf, **kwargs):
             cpt["product_absent_from_local_disks"] = len(df)
             return make_df2(df["safe"].tolist()), cpt
 
@@ -108,10 +117,7 @@ def patch_filter(monkeypatch):
 
 @pytest.fixture(autouse=True)
 def patch_semaphores():
-    with (
-        # patch("cdsodatacli.download.remove_semaphore_token_file") as tok,
-        patch("cdsodatacli.download.remove_semaphore_session_file") as sess,
-    ):
+    with patch("cdsodatacli.download.remove_semaphore_session_file") as sess:
         yield sess
 
 
@@ -139,6 +145,8 @@ class TestAllSuccessful:
 
     def test_returns_dataframe(self):
         safenames = ["SAFE_A", "SAFE_B"]
+        inputdf = make_inputdf(safenames)
+
         with (
             patch(
                 "cdsodatacli.download.get_sessions_download_available",
@@ -150,8 +158,7 @@ class TestAllSuccessful:
             ),
         ):
             result = download_list_product_multithread_v3(
-                list_id=["id0", "id1"],
-                list_safename=safenames,
+                inputdf=inputdf,
                 outputdir="/fake/out",
                 account_group="logins",
             )
@@ -159,10 +166,8 @@ class TestAllSuccessful:
 
     def test_all_status_1(self):
         safenames = ["SAFE_A", "SAFE_B"]
+        inputdf = make_inputdf(safenames)
 
-        # Define a side effect function instead of a list
-        # This will return a result for the safename requested,
-        # no matter how many times it is called.
         def mock_download_side_effect(session, header, url, output_path, **kw):
             safename = os.path.basename(output_path).replace(".zip", "")
             return make_future_result(safename)
@@ -174,19 +179,57 @@ class TestAllSuccessful:
             ),
             patch(
                 "cdsodatacli.download.CDS_Odata_download_one_product_v2",
-                side_effect=mock_download_side_effect,  # Use the function here
+                side_effect=mock_download_side_effect,
             ),
         ):
             result = download_list_product_multithread_v3(
-                list_id=["id0", "id1"],
-                list_safename=safenames,
+                inputdf=inputdf,
                 outputdir="/fake/out",
                 account_group="logins",
             )
 
-        # Now that the mock doesn't crash, we check that all
-        # unique products eventually succeeded.
         assert (result["status"] == 1).all()
+
+
+class TestInputValidation:
+    """Input contracts."""
+
+    def test_mismatched_safe_id_lengths_raise(self):
+        """inputdf missing required column triggers KeyError/AssertionError
+        before any network call is made."""
+        df = pd.DataFrame({
+            "safename": ["SAFE_A", "SAFE_B"],
+            # "id" intentionally absent — function must raise before network calls
+        })
+        with pytest.raises((AssertionError, KeyError)):
+            download_list_product_multithread_v3(
+                inputdf=df,
+                outputdir="/fake/out",
+                account_group="logins",
+            )
+
+    def test_status_column_created_if_absent(self, patch_filter):
+        """If inputdf has no 'status' column, v3 must add it silently."""
+        df = pd.DataFrame({
+            "safename": ["SAFE_A"],
+            "id": ["id0"],
+            # no 'status' column
+        })
+
+        def _all_done(cpt, df_in, outputdir, force_download, cdsodatacli_conf,
+                      **kwargs):
+            empty = df_in.iloc[:0].copy()
+            return empty, cpt
+
+        patch_filter.side_effect = _all_done
+
+        with patch("cdsodatacli.download.get_sessions_download_available"):
+            # Should not raise even though 'status' is missing in input
+            download_list_product_multithread_v3(
+                inputdf=df,
+                outputdir="/fake/out",
+                account_group="logins",
+            )
 
 
 class TestDownloadError:
@@ -194,6 +237,7 @@ class TestDownloadError:
 
     def test_failed_product_status_minus1(self):
         safenames = ["SAFE_OK", "SAFE_FAIL"]
+        inputdf = make_inputdf(safenames)
 
         def sessions_side_effect(conf, subset, **kw):
             pending = subset["safe"].tolist()
@@ -202,9 +246,8 @@ class TestDownloadError:
         def worker_side_effect(session, header, url, output_path, **kw):
             safename = os.path.basename(output_path).replace(".zip", "")
             if safename == "SAFE_FAIL":
-                return make_future_result(
-                    "SAFE_FAIL", status="Unauthorized", speed=np.nan
-                )
+                return make_future_result("SAFE_FAIL", status="Unauthorized",
+                                          speed=np.nan)
             return make_future_result(safename)
 
         with (
@@ -218,8 +261,7 @@ class TestDownloadError:
             ),
         ):
             result = download_list_product_multithread_v3(
-                list_id=["id0", "id1"],
-                list_safename=safenames,
+                inputdf=inputdf,
                 outputdir="/fake/out",
                 account_group="logins",
             )
@@ -228,10 +270,12 @@ class TestDownloadError:
 
 
 class TestWorkerException:
-    """Worker raises an unhandled exception (e.g. CalledProcessError)."""
+    """Worker raises an unhandled exception."""
 
     def test_exception_marks_product_as_error(self):
         safenames = ["SAFE_CRASH"]
+        inputdf = make_inputdf(safenames)
+
         with (
             patch(
                 "cdsodatacli.download.get_sessions_download_available",
@@ -243,8 +287,7 @@ class TestWorkerException:
             ),
         ):
             result = download_list_product_multithread_v3(
-                list_id=["id0"],
-                list_safename=safenames,
+                inputdf=inputdf,
                 outputdir="/fake/out",
                 account_group="logins",
             )
@@ -253,9 +296,9 @@ class TestWorkerException:
     def test_other_products_continue_after_exception(self):
         """A crash on one product must not abort the others."""
         safenames = ["SAFE_CRASH", "SAFE_OK"]
+        inputdf = make_inputdf(safenames)
 
         def sessions_side_effect(conf, subset, **kw):
-            # return only products still pending in subset
             pending = subset["safe"].tolist()
             return make_downloadable_df([s for s in safenames if s in pending])
 
@@ -276,8 +319,7 @@ class TestWorkerException:
             ),
         ):
             result = download_list_product_multithread_v3(
-                list_id=["id0", "id1"],
-                list_safename=safenames,
+                inputdf=inputdf,
                 outputdir="/fake/out",
                 account_group="logins",
             )
@@ -290,7 +332,8 @@ class TestNoDuplicateDownload:
 
     def test_duplicate_not_submitted(self):
         """currently_downloading must block re-submission of the same safename."""
-        safenames = ["SAFE_A", "SAFE_A"]  # duplicate in listing
+        safenames = ["SAFE_A", "SAFE_A"]
+        inputdf = make_inputdf(safenames, ids=["id0", "id0"])
         submission_count = {"n": 0}
 
         def tracking_worker(session, header, url, output_path, **kw):
@@ -309,12 +352,10 @@ class TestNoDuplicateDownload:
             ),
         ):
             download_list_product_multithread_v3(
-                list_id=["id0", "id0"],
-                list_safename=safenames,
+                inputdf=inputdf,
                 outputdir="/fake/out",
                 account_group="logins",
             )
-        # despite two entries in the listing, the worker must be called only once
         assert submission_count["n"] == 1
 
 
@@ -322,7 +363,8 @@ class TestAllAlreadyPresent:
     """All products already on disk — nothing to download."""
 
     def test_empty_df2_returns_immediately(self, patch_filter):
-        def _all_archived(cpt, df, outputdir, force_download, cdsodatacli_conf):
+        def _all_archived(cpt, df, outputdir, force_download, cdsodatacli_conf,
+                           **kwargs):
             cpt["archived_product"] = len(df)
             empty = pd.DataFrame({"safe": [], "status": [], "id": []})
             return empty, cpt
@@ -331,8 +373,7 @@ class TestAllAlreadyPresent:
 
         with patch("cdsodatacli.download.get_sessions_download_available") as mock_sess:
             download_list_product_multithread_v3(
-                list_id=["id0"],
-                list_safename=["SAFE_A"],
+                inputdf=make_inputdf(["SAFE_A"]),
                 outputdir="/fake/out",
                 account_group="logins",
             )
@@ -344,13 +385,17 @@ class TestNoSessionAvailable:
 
     def test_sleeps_when_no_session(self):
         safenames = ["SAFE_A"]
+        inputdf = make_inputdf(safenames)
         call_count = {"n": 0}
 
         def sessions_side_effect(*a, **kw):
             call_count["n"] += 1
             if call_count["n"] < 3:
-                return make_downloadable_df([])  # empty first 2 calls
+                return make_downloadable_df([])
             return make_downloadable_df(safenames)
+
+        def odata_worker(session, header, url, output_path, **kw):
+            return make_future_result(os.path.basename(output_path).replace(".zip", ""))
 
         with (
             patch(
@@ -359,41 +404,27 @@ class TestNoSessionAvailable:
             ),
             patch(
                 "cdsodatacli.download.CDS_Odata_download_one_product_v2",
-                return_value=make_future_result("SAFE_A"),
+                side_effect=odata_worker,
             ),
             patch("cdsodatacli.download.time.sleep") as mock_sleep,
         ):
             download_list_product_multithread_v3(
-                list_id=["id0"],
-                list_safename=safenames,
+                inputdf=inputdf,
                 outputdir="/fake/out",
                 account_group="logins",
             )
         assert mock_sleep.call_count >= 2
 
 
-class TestAssertLengths:
-    """list_id and list_safename must have the same length."""
-
-    def test_mismatched_lengths_raise(self):
-        with pytest.raises(AssertionError):
-            download_list_product_multithread_v3(
-                list_id=["id0", "id1"],
-                list_safename=["SAFE_A"],
-                outputdir="/fake/out",
-                account_group="logins",
-            )
-
-
 # ---------------------------------------------------------------------------
-# NEW: Race condition tests
+# Race condition tests
 # ---------------------------------------------------------------------------
 
 
 class TestRaceCondition:
     """
-    Verify that two threads cannot write the same .tmp file simultaneously
-    and that currently_downloading prevents double submission.
+    Verify that currently_downloading prevents double submission and that
+    true concurrency is achieved for distinct products.
     """
 
     def test_same_safename_submitted_only_once_across_loops(self):
@@ -402,20 +433,24 @@ class TestRaceCondition:
         outer while loop fires again.  It must NOT be re-submitted.
         """
         safenames = ["SAFE_SLOW"]
+        inputdf = make_inputdf(safenames)
         submission_count = {"n": 0}
         barrier = threading.Event()
 
+        # Release the barrier from a daemon thread — avoids the deadlock
+        # where the worker waits for the barrier but the barrier is set
+        # inside sessions_side_effect which only runs after the worker finishes.
+        def _release():
+            time.sleep(0.2)
+            barrier.set()
+        threading.Thread(target=_release, daemon=True).start()
+
         def slow_worker(session, header, url, output_path, **kw):
             submission_count["n"] += 1
-            barrier.wait(timeout=2)  # block until test releases it
+            assert barrier.wait(timeout=5), "barrier was never released"
             return make_future_result("SAFE_SLOW")
 
-        loop_count = {"n": 0}
-
         def sessions_side_effect(*a, **kw):
-            loop_count["n"] += 1
-            if loop_count["n"] == 1:
-                barrier.set()  # release the worker on 2nd loop entry
             return make_downloadable_df(safenames)
 
         with (
@@ -429,19 +464,16 @@ class TestRaceCondition:
             ),
         ):
             download_list_product_multithread_v3(
-                list_id=["id0"],
-                list_safename=safenames,
+                inputdf=inputdf,
                 outputdir="/fake/out",
                 account_group="logins",
             )
-        # despite multiple loop iterations, the worker must be called only once
         assert submission_count["n"] == 1
 
     def test_two_different_products_can_run_concurrently(self):
-        """
-        Two distinct products must both be submitted and both reach status=1.
-        """
+        """Two distinct products must both be submitted and both reach status=1."""
         safenames = ["SAFE_X", "SAFE_Y"]
+        inputdf = make_inputdf(safenames)
         active_at_same_time = {"count": 0, "max": 0}
         lock = threading.Lock()
 
@@ -452,7 +484,7 @@ class TestRaceCondition:
                 active_at_same_time["max"] = max(
                     active_at_same_time["max"], active_at_same_time["count"]
                 )
-            time.sleep(0.05)  # simulate real I/O overlap
+            time.sleep(0.05)
             with lock:
                 active_at_same_time["count"] -= 1
             return make_future_result(safename)
@@ -468,24 +500,20 @@ class TestRaceCondition:
             ),
         ):
             result = download_list_product_multithread_v3(
-                list_id=["id0", "id1"],
-                list_safename=safenames,
+                inputdf=inputdf,
                 outputdir="/fake/out",
                 account_group="logins",
             )
         assert (result["status"] == 1).all()
-        # both workers overlapped at least once (proves true parallelism)
         assert active_at_same_time["max"] >= 2
 
     def test_tmp_file_not_moved_twice(self):
         """
-        If two futures for the same product somehow complete (should not happen
-        after the fix), the second shutil.copy2 must not crash the daemon —
-        the FileNotFoundError on the already-removed .tmp must be caught.
+        If two futures for the same product somehow complete, the second
+        FileNotFoundError on the already-removed .tmp must be caught gracefully.
         """
         safenames = ["SAFE_RACE"]
-
-        # Simulate: first call succeeds, second finds .tmp already gone
+        inputdf = make_inputdf(safenames * 2, ids=["id0", "id0"])
         call_count = {"n": 0}
 
         def worker_with_race(session, header, url, output_path, **kw):
@@ -504,19 +532,16 @@ class TestRaceCondition:
                 side_effect=worker_with_race,
             ),
         ):
-            # should not raise — the exception must be caught by the except block
             result = download_list_product_multithread_v3(
-                list_id=["id0", "id0"],
-                list_safename=safenames * 2,
+                inputdf=inputdf,
                 outputdir="/fake/out",
                 account_group="logins",
             )
-        # at least one attempt succeeded
         assert (result["status"] != 0).any()
 
 
 # ---------------------------------------------------------------------------
-# NEW: Server not answering / network failure tests
+# Server not answering / network failure tests
 # ---------------------------------------------------------------------------
 
 
@@ -528,6 +553,7 @@ class TestServerNotAnswering:
 
     def _run_with_worker_error(self, exc, safenames=None):
         safenames = safenames or ["SAFE_NET"]
+        inputdf = make_inputdf(safenames)
         with (
             patch(
                 "cdsodatacli.download.get_sessions_download_available",
@@ -539,8 +565,7 @@ class TestServerNotAnswering:
             ),
         ):
             return download_list_product_multithread_v3(
-                list_id=["id0"] * len(safenames),
-                list_safename=safenames,
+                inputdf=inputdf,
                 outputdir="/fake/out",
                 account_group="logins",
             )
@@ -554,14 +579,13 @@ class TestServerNotAnswering:
         assert result.loc[result["safe"] == "SAFE_NET", "status"].iloc[0] == -1
 
     def test_chunked_encoding_error_marks_product_failed(self):
-        """ChunkedEncodingError is handled inside the worker but we test the
-        outer layer too in case the worker itself raises unexpectedly."""
         result = self._run_with_worker_error(ChunkedEncodingError("chunked"))
         assert result.loc[result["safe"] == "SAFE_NET", "status"].iloc[0] == -1
 
     def test_network_error_does_not_crash_daemon(self):
         """Other products must still succeed even if one hits a network error."""
         safenames = ["SAFE_TIMEOUT", "SAFE_OK"]
+        inputdf = make_inputdf(safenames)
 
         def sessions_side_effect(conf, subset, **kw):
             pending = subset["safe"].tolist()
@@ -584,8 +608,7 @@ class TestServerNotAnswering:
             ),
         ):
             result = download_list_product_multithread_v3(
-                list_id=["id0", "id1"],
-                list_safename=safenames,
+                inputdf=inputdf,
                 outputdir="/fake/out",
                 account_group="logins",
             )
@@ -593,11 +616,10 @@ class TestServerNotAnswering:
         assert result.loc[result["safe"] == "SAFE_TIMEOUT", "status"].iloc[0] == -1
 
     def test_http_503_returned_as_status_meaning(self):
-        """
-        Worker returns a non-OK status_meaning (e.g. 'Service Unavailable')
-        rather than raising — product must be marked -1, not retried forever.
-        """
+        """Non-OK status_meaning must mark product -1, not retry forever."""
         safenames = ["SAFE_503"]
+        inputdf = make_inputdf(safenames)
+
         with (
             patch(
                 "cdsodatacli.download.get_sessions_download_available",
@@ -611,18 +633,17 @@ class TestServerNotAnswering:
             ),
         ):
             result = download_list_product_multithread_v3(
-                list_id=["id0"],
-                list_safename=safenames,
+                inputdf=inputdf,
                 outputdir="/fake/out",
                 account_group="logins",
             )
         assert result.loc[result["safe"] == "SAFE_503", "status"].iloc[0] == -1
 
     def test_all_workers_timeout_loop_eventually_exits(self):
-        """
-        If every product fails, the while loop must terminate (no infinite loop).
-        """
+        """If every product fails, the while loop must terminate."""
         safenames = ["SAFE_A", "SAFE_B", "SAFE_C"]
+        inputdf = make_inputdf(safenames)
+
         with (
             patch(
                 "cdsodatacli.download.get_sessions_download_available",
@@ -634,29 +655,25 @@ class TestServerNotAnswering:
             ),
         ):
             result = download_list_product_multithread_v3(
-                list_id=["id0", "id1", "id2"],
-                list_safename=safenames,
+                inputdf=inputdf,
                 outputdir="/fake/out",
                 account_group="logins",
             )
-        # all must be settled (1 or -1), none stuck at 0
         assert (result["status"] != 0).all()
 
 
 # ---------------------------------------------------------------------------
-# NEW: Extended no-session / throttling tests
+# Extended no-session / throttling tests
 # ---------------------------------------------------------------------------
 
 
 class TestNoSessionExtended:
-    """
-    More thorough coverage of the 'no session available' branch,
-    including prolonged starvation and eventual recovery.
-    """
+    """More thorough coverage of the 'no session available' branch."""
 
     def test_sleep_duration_is_correct(self):
         """The code sleeps 5 seconds when no session is available."""
         safenames = ["SAFE_A"]
+        inputdf = make_inputdf(safenames)
         call_count = {"n": 0}
 
         def sessions_side_effect(*a, **kw):
@@ -665,6 +682,9 @@ class TestNoSessionExtended:
                 return make_downloadable_df([])
             return make_downloadable_df(safenames)
 
+        def odata_worker(session, header, url, output_path, **kw):
+            return make_future_result(os.path.basename(output_path).replace(".zip", ""))
+
         with (
             patch(
                 "cdsodatacli.download.get_sessions_download_available",
@@ -672,26 +692,22 @@ class TestNoSessionExtended:
             ),
             patch(
                 "cdsodatacli.download.CDS_Odata_download_one_product_v2",
-                return_value=make_future_result("SAFE_A"),
+                side_effect=odata_worker,
             ),
             patch("cdsodatacli.download.time.sleep") as mock_sleep,
         ):
             download_list_product_multithread_v3(
-                list_id=["id0"],
-                list_safename=safenames,
+                inputdf=inputdf,
                 outputdir="/fake/out",
                 account_group="logins",
             )
-        # each sleep call must use exactly 5 seconds
         for c in mock_sleep.call_args_list:
             assert c.args[0] == 5
 
     def test_many_empty_session_rounds_then_success(self):
-        """
-        Session starved for 10 rounds, then becomes available.
-        Product must eventually reach status=1.
-        """
+        """Session starved for 10 rounds then recovers — product must reach status=1."""
         safenames = ["SAFE_STARVED"]
+        inputdf = make_inputdf(safenames)
         call_count = {"n": 0}
 
         def sessions_side_effect(*a, **kw):
@@ -700,6 +716,9 @@ class TestNoSessionExtended:
                 return make_downloadable_df([])
             return make_downloadable_df(safenames)
 
+        def odata_worker(session, header, url, output_path, **kw):
+            return make_future_result(os.path.basename(output_path).replace(".zip", ""))
+
         with (
             patch(
                 "cdsodatacli.download.get_sessions_download_available",
@@ -707,13 +726,12 @@ class TestNoSessionExtended:
             ),
             patch(
                 "cdsodatacli.download.CDS_Odata_download_one_product_v2",
-                return_value=make_future_result("SAFE_STARVED"),
+                side_effect=odata_worker,
             ),
-            patch("cdsodatacli.download.time.sleep"),
+            patch("cdsodatacli.download.time.sleep"),  # don't actually sleep 10×5s
         ):
             result = download_list_product_multithread_v3(
-                list_id=["id0"],
-                list_safename=safenames,
+                inputdf=inputdf,
                 outputdir="/fake/out",
                 account_group="logins",
             )
@@ -722,6 +740,7 @@ class TestNoSessionExtended:
     def test_no_session_does_not_submit_any_future(self):
         """When sessions are empty, no future must be submitted to the executor."""
         safenames = ["SAFE_A"]
+        inputdf = make_inputdf(safenames)
         call_count = {"n": 0}
 
         def sessions_side_effect(*a, **kw):
@@ -748,10 +767,8 @@ class TestNoSessionExtended:
             patch("cdsodatacli.download.time.sleep"),
         ):
             download_list_product_multithread_v3(
-                list_id=["id0"],
-                list_safename=safenames,
+                inputdf=inputdf,
                 outputdir="/fake/out",
                 account_group="logins",
             )
-        # worker called exactly once (only after session became available)
         assert len(submitted) == 1

--- a/tests/test_download_s3endpoint.py
+++ b/tests/test_download_s3endpoint.py
@@ -12,10 +12,8 @@ import threading
 import pytest
 import numpy as np
 import pandas as pd
-from collections import defaultdict
-from unittest.mock import patch, MagicMock, call
+from unittest.mock import patch, MagicMock
 from botocore.exceptions import BotoCoreError, ClientError
-from requests.exceptions import ConnectionError, Timeout
 
 
 # ---------------------------------------------------------------------------
@@ -49,6 +47,7 @@ FAKE_CREDENTIALS = {"access_id": FAKE_ACCESS_ID}
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def make_s3_object(key, size=1_000_000):
     """Return a MagicMock mimicking a boto3 S3 ObjectSummary."""
     obj = MagicMock()
@@ -74,8 +73,13 @@ def make_s3_client_mocks(objects):
     return FAKE_CREDENTIALS, mock_s3_resource
 
 
-def make_s3_result(safename=FAKE_SAFENAME, status="Downloaded",
-                   speed=50.0, elapsed=20.0, total_mb=500.0):
+def make_s3_result(
+    safename=FAKE_SAFENAME,
+    status="Downloaded",
+    speed=50.0,
+    elapsed=20.0,
+    total_mb=500.0,
+):
     """Return a tuple matching cds_s3_download_one_product's return signature."""
     return speed, elapsed, total_mb, status, safename
 
@@ -84,38 +88,39 @@ def make_inputdf(safenames, s3paths=None, statuses=None):
     """Build a minimal inputdf as download_list_product_multithread_v4 expects."""
     n = len(safenames)
     if s3paths is None:
-        s3paths = [
-            f"Sentinel-1/SAR/GRD/2022/05/03/{s}.SAFE" for s in safenames
-        ]
+        s3paths = [f"Sentinel-1/SAR/GRD/2022/05/03/{s}.SAFE" for s in safenames]
     if statuses is None:
         statuses = np.zeros(n)
-    return pd.DataFrame({
-        "safename": safenames,
-        "S3Path": s3paths,
-        "id": [f"id-{i}" for i in range(n)],
-        "status": statuses,
-    })
+    return pd.DataFrame(
+        {
+            "safename": safenames,
+            "S3Path": s3paths,
+            "id": [f"id-{i}" for i in range(n)],
+            "status": statuses,
+        }
+    )
 
 
 def make_downloadable_df(safenames, s3paths=None):
     """Simulate the output of get_sessions_download_available for v4."""
     n = len(safenames)
     if s3paths is None:
-        s3paths = [
-            f"Sentinel-1/SAR/GRD/2022/05/03/{s}.SAFE" for s in safenames
-        ]
-    return pd.DataFrame({
-        "safe": safenames,
-        "header": [FAKE_HEADER for _ in range(n)],
-        "output_path": [f"/fake/spool/{s}" for s in safenames],
-        "S3Path": s3paths,
-        "login": ["user1@example.fr"] * n,
-    })
+        s3paths = [f"Sentinel-1/SAR/GRD/2022/05/03/{s}.SAFE" for s in safenames]
+    return pd.DataFrame(
+        {
+            "safe": safenames,
+            "header": [FAKE_HEADER for _ in range(n)],
+            "output_path": [f"/fake/spool/{s}" for s in safenames],
+            "S3Path": s3paths,
+            "login": ["user1@example.fr"] * n,
+        }
+    )
 
 
 # ---------------------------------------------------------------------------
 # Fixtures (autouse)
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture(autouse=True)
 def patch_conf():
@@ -139,13 +144,13 @@ def patch_tqdm():
 def patch_filter():
     """Default: all products need downloading (status=0)."""
     with patch("cdsodatacli.download.filter_product_already_present") as mock:
-        def _default(cpt, df, outputdir, force_download, cdsodatacli_conf,
-                     extension=""):
+
+        def _default(
+            cpt, df, outputdir, force_download, cdsodatacli_conf, extension=""
+        ):
             cpt["product_absent_from_local_disks"] = len(df)
             result = df.copy()
-            result["outputpath"] = [
-                f"/fake/spool/{s}" for s in result["safe"]
-            ]
+            result["outputpath"] = [f"/fake/spool/{s}" for s in result["safe"]]
             return result, cpt
 
         mock.side_effect = _default
@@ -175,6 +180,7 @@ from cdsodatacli.download import (  # noqa: E402
 # Part 1 — cds_s3_download_one_product unit tests
 # ===========================================================================
 
+
 class TestCdsS3DownloadOneProductSuccess:
     """Happy path: single-object product downloads and moves correctly."""
 
@@ -186,8 +192,10 @@ class TestCdsS3DownloadOneProductSuccess:
         conf = {**FAKE_CONF, "pre_spool": str(tmp_path)}
 
         with (
-            patch("cdsodatacli.download._get_fresh_s3_client",
-                  return_value=(creds, s3_resource)),
+            patch(
+                "cdsodatacli.download._get_fresh_s3_client",
+                return_value=(creds, s3_resource),
+            ),
             patch("shutil.copy2"),
             patch("os.remove"),
             patch("os.chmod"),
@@ -206,8 +214,10 @@ class TestCdsS3DownloadOneProductSuccess:
         conf = {**FAKE_CONF, "pre_spool": str(tmp_path)}
 
         with (
-            patch("cdsodatacli.download._get_fresh_s3_client",
-                  return_value=(creds, s3_resource)),
+            patch(
+                "cdsodatacli.download._get_fresh_s3_client",
+                return_value=(creds, s3_resource),
+            ),
             patch("shutil.copy2"),
             patch("os.remove"),
             patch("os.chmod"),
@@ -226,8 +236,10 @@ class TestCdsS3DownloadOneProductSuccess:
         conf = {**FAKE_CONF, "pre_spool": str(tmp_path)}
 
         with (
-            patch("cdsodatacli.download._get_fresh_s3_client",
-                  return_value=(creds, s3_resource)),
+            patch(
+                "cdsodatacli.download._get_fresh_s3_client",
+                return_value=(creds, s3_resource),
+            ),
             patch("shutil.copy2"),
             patch("os.remove"),
             patch("os.chmod"),
@@ -247,8 +259,10 @@ class TestCdsS3DownloadOneProductSuccess:
         conf = {**FAKE_CONF, "pre_spool": str(tmp_path)}
 
         with (
-            patch("cdsodatacli.download._get_fresh_s3_client",
-                  return_value=(creds, s3_resource)),
+            patch(
+                "cdsodatacli.download._get_fresh_s3_client",
+                return_value=(creds, s3_resource),
+            ),
             patch("shutil.copy2"),
             patch("os.remove"),
             patch("os.chmod"),
@@ -271,8 +285,10 @@ class TestCdsS3DownloadOneProductSuccess:
         expected_tmp = os.path.join(str(tmp_path), f"{FAKE_SAFENAME}.zip.tmp")
 
         with (
-            patch("cdsodatacli.download._get_fresh_s3_client",
-                  return_value=(creds, s3_resource)),
+            patch(
+                "cdsodatacli.download._get_fresh_s3_client",
+                return_value=(creds, s3_resource),
+            ),
             patch("shutil.copy2") as mock_copy,
             patch("os.remove"),
             patch("os.chmod"),
@@ -289,8 +305,10 @@ class TestCdsS3DownloadOneProductSuccess:
         conf = {**FAKE_CONF, "pre_spool": str(tmp_path)}
 
         with (
-            patch("cdsodatacli.download._get_fresh_s3_client",
-                  return_value=(creds, s3_resource)),
+            patch(
+                "cdsodatacli.download._get_fresh_s3_client",
+                return_value=(creds, s3_resource),
+            ),
             patch("shutil.copy2"),
             patch("os.remove"),
             patch("os.chmod"),
@@ -308,10 +326,12 @@ class TestCdsS3DownloadMultiFile:
     def test_multifile_status_downloaded(self, tmp_path):
         objects = [
             make_s3_object(f"{FAKE_S3_PATH}/manifest.safe", size=1_000),
-            make_s3_object(f"{FAKE_S3_PATH}/measurement/s1a-iw-grd-vv.tiff",
-                           size=300_000_000),
-            make_s3_object(f"{FAKE_S3_PATH}/measurement/s1a-iw-grd-vh.tiff",
-                           size=200_000_000),
+            make_s3_object(
+                f"{FAKE_S3_PATH}/measurement/s1a-iw-grd-vv.tiff", size=300_000_000
+            ),
+            make_s3_object(
+                f"{FAKE_S3_PATH}/measurement/s1a-iw-grd-vh.tiff", size=200_000_000
+            ),
         ]
         creds, s3_resource = make_s3_client_mocks(objects)
 
@@ -319,8 +339,10 @@ class TestCdsS3DownloadMultiFile:
         conf = {**FAKE_CONF, "pre_spool": str(tmp_path)}
 
         with (
-            patch("cdsodatacli.download._get_fresh_s3_client",
-                  return_value=(creds, s3_resource)),
+            patch(
+                "cdsodatacli.download._get_fresh_s3_client",
+                return_value=(creds, s3_resource),
+            ),
             patch("os.makedirs"),
         ):
             speed, elapsed, total_mb, status, safename = cds_s3_download_one_product(
@@ -341,8 +363,10 @@ class TestCdsS3DownloadMultiFile:
         conf = {**FAKE_CONF, "pre_spool": str(tmp_path)}
 
         with (
-            patch("cdsodatacli.download._get_fresh_s3_client",
-                  return_value=(creds, s3_resource)),
+            patch(
+                "cdsodatacli.download._get_fresh_s3_client",
+                return_value=(creds, s3_resource),
+            ),
             patch("os.makedirs"),
         ):
             cds_s3_download_one_product(FAKE_S3_PATH, FAKE_HEADER, output, conf)
@@ -361,8 +385,10 @@ class TestCdsS3DownloadErrors:
         output = str(tmp_path / f"{FAKE_SAFENAME}.zip")
         conf = {**FAKE_CONF, "pre_spool": str(tmp_path)}
 
-        with patch("cdsodatacli.download._get_fresh_s3_client",
-                   return_value=(creds, s3_resource)):
+        with patch(
+            "cdsodatacli.download._get_fresh_s3_client",
+            return_value=(creds, s3_resource),
+        ):
             _, _, _, status, _ = cds_s3_download_one_product(
                 FAKE_S3_PATH, FAKE_HEADER, output, conf
             )
@@ -378,8 +404,10 @@ class TestCdsS3DownloadErrors:
         output = str(tmp_path / f"{FAKE_SAFENAME}.zip")
         conf = {**FAKE_CONF, "pre_spool": str(tmp_path)}
 
-        with patch("cdsodatacli.download._get_fresh_s3_client",
-                   return_value=(creds, s3_resource)):
+        with patch(
+            "cdsodatacli.download._get_fresh_s3_client",
+            return_value=(creds, s3_resource),
+        ):
             _, _, _, status, _ = cds_s3_download_one_product(
                 FAKE_S3_PATH, FAKE_HEADER, output, conf
             )
@@ -393,8 +421,10 @@ class TestCdsS3DownloadErrors:
         output = str(tmp_path / f"{FAKE_SAFENAME}.zip")
         conf = {**FAKE_CONF, "pre_spool": str(tmp_path)}
 
-        with patch("cdsodatacli.download._get_fresh_s3_client",
-                   return_value=(creds, s3_resource)):
+        with patch(
+            "cdsodatacli.download._get_fresh_s3_client",
+            return_value=(creds, s3_resource),
+        ):
             _, _, _, status, _ = cds_s3_download_one_product(
                 FAKE_S3_PATH, FAKE_HEADER, output, conf
             )
@@ -421,8 +451,10 @@ class TestCdsS3DownloadErrors:
         # Create a dummy .tmp to simulate partial download
         open(tmp_file, "w").close()
 
-        with patch("cdsodatacli.download._get_fresh_s3_client",
-                   return_value=(creds, s3_resource)):
+        with patch(
+            "cdsodatacli.download._get_fresh_s3_client",
+            return_value=(creds, s3_resource),
+        ):
             cds_s3_download_one_product(FAKE_S3_PATH, FAKE_HEADER, output, conf)
 
         assert not os.path.exists(tmp_file), ".tmp file should have been cleaned up"
@@ -435,8 +467,10 @@ class TestCdsS3DownloadErrors:
         conf = {**FAKE_CONF, "pre_spool": str(tmp_path)}
 
         with (
-            patch("cdsodatacli.download._get_fresh_s3_client",
-                  return_value=(creds, s3_resource)),
+            patch(
+                "cdsodatacli.download._get_fresh_s3_client",
+                return_value=(creds, s3_resource),
+            ),
             patch("shutil.copy2", side_effect=OSError("disk full")),
             patch("os.remove"),
         ):
@@ -453,8 +487,10 @@ class TestCdsS3DownloadErrors:
         output = str(tmp_path / f"{FAKE_SAFENAME}.zip")
         conf = {**FAKE_CONF, "pre_spool": str(tmp_path)}
 
-        with patch("cdsodatacli.download._get_fresh_s3_client",
-                   return_value=(creds, s3_resource)):
+        with patch(
+            "cdsodatacli.download._get_fresh_s3_client",
+            return_value=(creds, s3_resource),
+        ):
             cds_s3_download_one_product(FAKE_S3_PATH, FAKE_HEADER, output, conf)
 
         assert patch_requests_delete.call_count == 1
@@ -464,17 +500,20 @@ class TestCdsS3DownloadErrors:
 # Part 2 — download_list_product_multithread_v4 integration tests
 # ===========================================================================
 
+
 class TestV4InputValidation:
     """Input contracts."""
 
     def test_mismatched_lengths_raise(self):
         # S3Path column absent — KeyError fires inside the function before
         # any network call is made, satisfying the input-contract test.
-        df = pd.DataFrame({
-            "safename": ["SAFE_A", "SAFE_B"],
-            "id": ["id0", "id1"],
-            # "S3Path" intentionally absent
-        })
+        df = pd.DataFrame(
+            {
+                "safename": ["SAFE_A", "SAFE_B"],
+                "id": ["id0", "id1"],
+                # "S3Path" intentionally absent
+            }
+        )
         with pytest.raises((AssertionError, KeyError)):
             download_list_product_multithread_v4(
                 df, "/fake/out", account_group="logins"
@@ -483,15 +522,18 @@ class TestV4InputValidation:
     def test_status_column_created_if_absent(self, patch_filter):
         """If inputdf has no 'status' column, v4 must add it silently."""
         safenames = ["SAFE_A"]
-        df = pd.DataFrame({
-            "safename": safenames,
-            "S3Path": ["Sentinel-1/SAR/GRD/2022/05/03/SAFE_A.SAFE"],
-            "id": ["id0"],
-            # no 'status' column
-        })
+        df = pd.DataFrame(
+            {
+                "safename": safenames,
+                "S3Path": ["Sentinel-1/SAR/GRD/2022/05/03/SAFE_A.SAFE"],
+                "id": ["id0"],
+                # no 'status' column
+            }
+        )
 
-        def _all_done(cpt, df_in, outputdir, force_download, cdsodatacli_conf,
-                      extension=""):
+        def _all_done(
+            cpt, df_in, outputdir, force_download, cdsodatacli_conf, extension=""
+        ):
             # return empty so the while loop exits immediately
             empty = df_in.iloc[:0].copy()
             return empty, cpt
@@ -513,10 +555,14 @@ class TestV4AllSuccessful:
         inputdf = make_inputdf(safenames)
 
         with (
-            patch("cdsodatacli.download.get_sessions_download_available",
-                  return_value=make_downloadable_df(safenames)),
-            patch("cdsodatacli.download.cds_s3_download_one_product",
-                  side_effect=[make_s3_result(s) for s in safenames]),
+            patch(
+                "cdsodatacli.download.get_sessions_download_available",
+                return_value=make_downloadable_df(safenames),
+            ),
+            patch(
+                "cdsodatacli.download.cds_s3_download_one_product",
+                side_effect=[make_s3_result(s) for s in safenames],
+            ),
         ):
             result = download_list_product_multithread_v4(
                 inputdf, "/fake/out", account_group="logins"
@@ -533,10 +579,14 @@ class TestV4AllSuccessful:
             return make_s3_result(safename)
 
         with (
-            patch("cdsodatacli.download.get_sessions_download_available",
-                  return_value=make_downloadable_df(safenames)),
-            patch("cdsodatacli.download.cds_s3_download_one_product",
-                  side_effect=mock_s3_worker),
+            patch(
+                "cdsodatacli.download.get_sessions_download_available",
+                return_value=make_downloadable_df(safenames),
+            ),
+            patch(
+                "cdsodatacli.download.cds_s3_download_one_product",
+                side_effect=mock_s3_worker,
+            ),
         ):
             result = download_list_product_multithread_v4(
                 inputdf, "/fake/out", account_group="logins"
@@ -550,10 +600,14 @@ class TestV4AllSuccessful:
         inputdf = make_inputdf(safenames)
 
         with (
-            patch("cdsodatacli.download.get_sessions_download_available",
-                  return_value=make_downloadable_df(safenames)),
-            patch("cdsodatacli.download.cds_s3_download_one_product",
-                  return_value=make_s3_result("SAFE_A", status="OK")),
+            patch(
+                "cdsodatacli.download.get_sessions_download_available",
+                return_value=make_downloadable_df(safenames),
+            ),
+            patch(
+                "cdsodatacli.download.cds_s3_download_one_product",
+                return_value=make_s3_result("SAFE_A", status="OK"),
+            ),
         ):
             result = download_list_product_multithread_v4(
                 inputdf, "/fake/out", account_group="logins"
@@ -570,11 +624,16 @@ class TestV4DownloadErrors:
         inputdf = make_inputdf(safenames)
 
         with (
-            patch("cdsodatacli.download.get_sessions_download_available",
-                  return_value=make_downloadable_df(safenames)),
-            patch("cdsodatacli.download.cds_s3_download_one_product",
-                  return_value=make_s3_result("SAFE_MISSING", status="NotFound",
-                                              speed=np.nan)),
+            patch(
+                "cdsodatacli.download.get_sessions_download_available",
+                return_value=make_downloadable_df(safenames),
+            ),
+            patch(
+                "cdsodatacli.download.cds_s3_download_one_product",
+                return_value=make_s3_result(
+                    "SAFE_MISSING", status="NotFound", speed=np.nan
+                ),
+            ),
         ):
             result = download_list_product_multithread_v4(
                 inputdf, "/fake/out", account_group="logins"
@@ -587,11 +646,14 @@ class TestV4DownloadErrors:
         inputdf = make_inputdf(safenames)
 
         with (
-            patch("cdsodatacli.download.get_sessions_download_available",
-                  return_value=make_downloadable_df(safenames)),
-            patch("cdsodatacli.download.cds_s3_download_one_product",
-                  return_value=make_s3_result("SAFE_ERR", status="S3Error",
-                                              speed=np.nan)),
+            patch(
+                "cdsodatacli.download.get_sessions_download_available",
+                return_value=make_downloadable_df(safenames),
+            ),
+            patch(
+                "cdsodatacli.download.cds_s3_download_one_product",
+                return_value=make_s3_result("SAFE_ERR", status="S3Error", speed=np.nan),
+            ),
         ):
             result = download_list_product_multithread_v4(
                 inputdf, "/fake/out", account_group="logins"
@@ -604,10 +666,14 @@ class TestV4DownloadErrors:
         inputdf = make_inputdf(safenames)
 
         with (
-            patch("cdsodatacli.download.get_sessions_download_available",
-                  return_value=make_downloadable_df(safenames)),
-            patch("cdsodatacli.download.cds_s3_download_one_product",
-                  side_effect=RuntimeError("unexpected crash")),
+            patch(
+                "cdsodatacli.download.get_sessions_download_available",
+                return_value=make_downloadable_df(safenames),
+            ),
+            patch(
+                "cdsodatacli.download.cds_s3_download_one_product",
+                side_effect=RuntimeError("unexpected crash"),
+            ),
         ):
             result = download_list_product_multithread_v4(
                 inputdf, "/fake/out", account_group="logins"
@@ -630,10 +696,13 @@ class TestV4DownloadErrors:
             return make_s3_result(safename)
 
         with (
-            patch("cdsodatacli.download.get_sessions_download_available",
-                  side_effect=sessions_side_effect),
-            patch("cdsodatacli.download.cds_s3_download_one_product",
-                  side_effect=worker),
+            patch(
+                "cdsodatacli.download.get_sessions_download_available",
+                side_effect=sessions_side_effect,
+            ),
+            patch(
+                "cdsodatacli.download.cds_s3_download_one_product", side_effect=worker
+            ),
         ):
             result = download_list_product_multithread_v4(
                 inputdf, "/fake/out", account_group="logins"
@@ -652,10 +721,14 @@ class TestV4DownloadErrors:
             return make_s3_result(safename, status="S3Error", speed=np.nan)
 
         with (
-            patch("cdsodatacli.download.get_sessions_download_available",
-                  return_value=make_downloadable_df(safenames)),
-            patch("cdsodatacli.download.cds_s3_download_one_product",
-                  side_effect=failing_worker),
+            patch(
+                "cdsodatacli.download.get_sessions_download_available",
+                return_value=make_downloadable_df(safenames),
+            ),
+            patch(
+                "cdsodatacli.download.cds_s3_download_one_product",
+                side_effect=failing_worker,
+            ),
         ):
             result = download_list_product_multithread_v4(
                 inputdf, "/fake/out", account_group="logins"
@@ -677,10 +750,14 @@ class TestV4NoDuplicateDownload:
             return make_s3_result("SAFE_A")
 
         with (
-            patch("cdsodatacli.download.get_sessions_download_available",
-                  return_value=make_downloadable_df(safenames)),
-            patch("cdsodatacli.download.cds_s3_download_one_product",
-                  side_effect=tracking_worker),
+            patch(
+                "cdsodatacli.download.get_sessions_download_available",
+                return_value=make_downloadable_df(safenames),
+            ),
+            patch(
+                "cdsodatacli.download.cds_s3_download_one_product",
+                side_effect=tracking_worker,
+            ),
         ):
             download_list_product_multithread_v4(
                 inputdf, "/fake/out", account_group="logins"
@@ -693,8 +770,9 @@ class TestV4AllAlreadyPresent:
     """All products already on disk — nothing to download."""
 
     def test_empty_df2_skips_sessions(self, patch_filter):
-        def _all_archived(cpt, df_in, outputdir, force_download,
-                          cdsodatacli_conf, extension=""):
+        def _all_archived(
+            cpt, df_in, outputdir, force_download, cdsodatacli_conf, extension=""
+        ):
             cpt["archived_product"] = len(df_in)
             empty = df_in.iloc[:0].copy()
             return empty, cpt
@@ -727,10 +805,14 @@ class TestV4NoSession:
             return make_s3_result(os.path.basename(output_path))
 
         with (
-            patch("cdsodatacli.download.get_sessions_download_available",
-                  side_effect=sessions_side_effect),
-            patch("cdsodatacli.download.cds_s3_download_one_product",
-                  side_effect=s3_worker),
+            patch(
+                "cdsodatacli.download.get_sessions_download_available",
+                side_effect=sessions_side_effect,
+            ),
+            patch(
+                "cdsodatacli.download.cds_s3_download_one_product",
+                side_effect=s3_worker,
+            ),
             patch("cdsodatacli.download.time.sleep") as mock_sleep,
         ):
             download_list_product_multithread_v4(
@@ -754,10 +836,14 @@ class TestV4NoSession:
             return make_s3_result(os.path.basename(output_path))
 
         with (
-            patch("cdsodatacli.download.get_sessions_download_available",
-                  side_effect=sessions_side_effect),
-            patch("cdsodatacli.download.cds_s3_download_one_product",
-                  side_effect=s3_worker),
+            patch(
+                "cdsodatacli.download.get_sessions_download_available",
+                side_effect=sessions_side_effect,
+            ),
+            patch(
+                "cdsodatacli.download.cds_s3_download_one_product",
+                side_effect=s3_worker,
+            ),
             patch("cdsodatacli.download.time.sleep") as mock_sleep,
         ):
             download_list_product_multithread_v4(
@@ -775,8 +861,9 @@ class TestV4FilterCalledWithExtensionEmpty:
         safenames = ["SAFE_A"]
         inputdf = make_inputdf(safenames)
 
-        def _capture(cpt, df_in, outputdir, force_download,
-                     cdsodatacli_conf, extension=""):
+        def _capture(
+            cpt, df_in, outputdir, force_download, cdsodatacli_conf, extension=""
+        ):
             _capture.extension_used = extension
             empty = df_in.iloc[:0].copy()
             return empty, cpt
@@ -812,10 +899,14 @@ class TestV4Concurrency:
             return make_s3_result(safename)
 
         with (
-            patch("cdsodatacli.download.get_sessions_download_available",
-                  return_value=make_downloadable_df(safenames)),
-            patch("cdsodatacli.download.cds_s3_download_one_product",
-                  side_effect=concurrent_worker),
+            patch(
+                "cdsodatacli.download.get_sessions_download_available",
+                return_value=make_downloadable_df(safenames),
+            ),
+            patch(
+                "cdsodatacli.download.cds_s3_download_one_product",
+                side_effect=concurrent_worker,
+            ),
         ):
             result = download_list_product_multithread_v4(
                 inputdf, "/fake/out", account_group="logins"
@@ -852,10 +943,14 @@ class TestV4Concurrency:
             return make_s3_result("SAFE_SLOW")
 
         with (
-            patch("cdsodatacli.download.get_sessions_download_available",
-                  return_value=make_downloadable_df(safenames)),
-            patch("cdsodatacli.download.cds_s3_download_one_product",
-                  side_effect=slow_worker),
+            patch(
+                "cdsodatacli.download.get_sessions_download_available",
+                return_value=make_downloadable_df(safenames),
+            ),
+            patch(
+                "cdsodatacli.download.cds_s3_download_one_product",
+                side_effect=slow_worker,
+            ),
         ):
             download_list_product_multithread_v4(
                 inputdf, "/fake/out", account_group="logins"

--- a/tests/test_download_s3endpoint.py
+++ b/tests/test_download_s3endpoint.py
@@ -1,0 +1,864 @@
+"""
+pytest unit tests for:
+  - cds_s3_download_one_product
+  - download_list_product_multithread_v4
+
+Run with: pytest test_download_s3.py -v
+"""
+
+import os
+import time
+import threading
+import pytest
+import numpy as np
+import pandas as pd
+from collections import defaultdict
+from unittest.mock import patch, MagicMock, call
+from botocore.exceptions import BotoCoreError, ClientError
+from requests.exceptions import ConnectionError, Timeout
+
+
+# ---------------------------------------------------------------------------
+# Shared constants
+# ---------------------------------------------------------------------------
+
+FAKE_CONF = {
+    "token_directory": "/fake/token_dir",
+    "active_session_directory": "/fake/session_dir",
+    "pre_spool": "/fake/pre_spool",
+    "spool": "/fake/spool",
+    "s3_bucket": "eodata",
+    "s3_endpoint": "https://eodata.dataspace.copernicus.eu",
+    "s3_region": "default",
+    "URL_download": "https://fake.cdse/odata/v1/Products(%s)/$value",
+    "logins": {
+        "user1@example.fr": "passwd1",
+        "user2@example.fr": "passwd2",
+    },
+}
+
+FAKE_S3_PATH = "Sentinel-1/SAR/GRD/2022/05/03/S1A_IW_GRDH_1SDV_20220503T000000.SAFE"
+FAKE_SAFENAME = "S1A_IW_GRDH_1SDV_20220503T000000"
+FAKE_OUTPUT = f"/fake/spool/{FAKE_SAFENAME}.zip"
+FAKE_HEADER = {"Authorization": "Bearer fake-token"}
+FAKE_ACCESS_ID = "fake-access-id-123"
+FAKE_CREDENTIALS = {"access_id": FAKE_ACCESS_ID}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_s3_object(key, size=1_000_000):
+    """Return a MagicMock mimicking a boto3 S3 ObjectSummary."""
+    obj = MagicMock()
+    obj.key = key
+    obj.size = size
+    return obj
+
+
+def make_s3_client_mocks(objects):
+    """
+    Return (mock_credentials, mock_s3_resource) pair suitable for
+    patching _get_fresh_s3_client.
+
+    objects: list of MagicMock s3 ObjectSummary instances
+    """
+    mock_bucket = MagicMock()
+    mock_bucket.objects.filter.return_value = objects
+    mock_bucket.download_file = MagicMock()
+
+    mock_s3_resource = MagicMock()
+    mock_s3_resource.Bucket.return_value = mock_bucket
+
+    return FAKE_CREDENTIALS, mock_s3_resource
+
+
+def make_s3_result(safename=FAKE_SAFENAME, status="Downloaded",
+                   speed=50.0, elapsed=20.0, total_mb=500.0):
+    """Return a tuple matching cds_s3_download_one_product's return signature."""
+    return speed, elapsed, total_mb, status, safename
+
+
+def make_inputdf(safenames, s3paths=None, statuses=None):
+    """Build a minimal inputdf as download_list_product_multithread_v4 expects."""
+    n = len(safenames)
+    if s3paths is None:
+        s3paths = [
+            f"Sentinel-1/SAR/GRD/2022/05/03/{s}.SAFE" for s in safenames
+        ]
+    if statuses is None:
+        statuses = np.zeros(n)
+    return pd.DataFrame({
+        "safename": safenames,
+        "S3Path": s3paths,
+        "id": [f"id-{i}" for i in range(n)],
+        "status": statuses,
+    })
+
+
+def make_downloadable_df(safenames, s3paths=None):
+    """Simulate the output of get_sessions_download_available for v4."""
+    n = len(safenames)
+    if s3paths is None:
+        s3paths = [
+            f"Sentinel-1/SAR/GRD/2022/05/03/{s}.SAFE" for s in safenames
+        ]
+    return pd.DataFrame({
+        "safe": safenames,
+        "header": [FAKE_HEADER for _ in range(n)],
+        "output_path": [f"/fake/spool/{s}" for s in safenames],
+        "S3Path": s3paths,
+        "login": ["user1@example.fr"] * n,
+    })
+
+
+# ---------------------------------------------------------------------------
+# Fixtures (autouse)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def patch_conf():
+    with patch("cdsodatacli.download.get_conf", return_value=FAKE_CONF):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def patch_semaphores():
+    with patch("cdsodatacli.download.remove_semaphore_session_file"):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def patch_tqdm():
+    with patch("cdsodatacli.download.tqdm", side_effect=lambda *a, **kw: MagicMock()):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def patch_filter():
+    """Default: all products need downloading (status=0)."""
+    with patch("cdsodatacli.download.filter_product_already_present") as mock:
+        def _default(cpt, df, outputdir, force_download, cdsodatacli_conf,
+                     extension=""):
+            cpt["product_absent_from_local_disks"] = len(df)
+            result = df.copy()
+            result["outputpath"] = [
+                f"/fake/spool/{s}" for s in result["safe"]
+            ]
+            return result, cpt
+
+        mock.side_effect = _default
+        yield mock
+
+
+@pytest.fixture(autouse=True)
+def patch_requests_delete():
+    """Prevent real HTTP calls for credential cleanup."""
+    mock_resp = MagicMock()
+    mock_resp.status_code = 204
+    with patch("cdsodatacli.download.requests.delete", return_value=mock_resp) as m:
+        yield m
+
+
+# ---------------------------------------------------------------------------
+# Import after fixtures so module-level calls don't fail
+# ---------------------------------------------------------------------------
+
+from cdsodatacli.download import (  # noqa: E402
+    cds_s3_download_one_product,
+    download_list_product_multithread_v4,
+)
+
+
+# ===========================================================================
+# Part 1 — cds_s3_download_one_product unit tests
+# ===========================================================================
+
+class TestCdsS3DownloadOneProductSuccess:
+    """Happy path: single-object product downloads and moves correctly."""
+
+    def test_returns_five_values(self, tmp_path):
+        obj = make_s3_object(FAKE_S3_PATH + "/product.zip", size=500_000_000)
+        creds, s3_resource = make_s3_client_mocks([obj])
+
+        output = str(tmp_path / f"{FAKE_SAFENAME}.zip")
+        conf = {**FAKE_CONF, "pre_spool": str(tmp_path)}
+
+        with (
+            patch("cdsodatacli.download._get_fresh_s3_client",
+                  return_value=(creds, s3_resource)),
+            patch("shutil.copy2"),
+            patch("os.remove"),
+            patch("os.chmod"),
+        ):
+            result = cds_s3_download_one_product(
+                FAKE_S3_PATH, FAKE_HEADER, output, conf
+            )
+
+        assert len(result) == 5
+
+    def test_status_is_downloaded_on_success(self, tmp_path):
+        obj = make_s3_object(FAKE_S3_PATH + "/product.zip", size=200_000_000)
+        creds, s3_resource = make_s3_client_mocks([obj])
+
+        output = str(tmp_path / f"{FAKE_SAFENAME}.zip")
+        conf = {**FAKE_CONF, "pre_spool": str(tmp_path)}
+
+        with (
+            patch("cdsodatacli.download._get_fresh_s3_client",
+                  return_value=(creds, s3_resource)),
+            patch("shutil.copy2"),
+            patch("os.remove"),
+            patch("os.chmod"),
+        ):
+            speed, elapsed, total_mb, status, safename = cds_s3_download_one_product(
+                FAKE_S3_PATH, FAKE_HEADER, output, conf
+            )
+
+        assert status == "Downloaded"
+
+    def test_safename_base_strips_zip(self, tmp_path):
+        obj = make_s3_object(FAKE_S3_PATH + "/product.zip")
+        creds, s3_resource = make_s3_client_mocks([obj])
+
+        output = str(tmp_path / f"{FAKE_SAFENAME}.zip")
+        conf = {**FAKE_CONF, "pre_spool": str(tmp_path)}
+
+        with (
+            patch("cdsodatacli.download._get_fresh_s3_client",
+                  return_value=(creds, s3_resource)),
+            patch("shutil.copy2"),
+            patch("os.remove"),
+            patch("os.chmod"),
+        ):
+            *_, safename = cds_s3_download_one_product(
+                FAKE_S3_PATH, FAKE_HEADER, output, conf
+            )
+
+        assert safename == FAKE_SAFENAME
+        assert ".zip" not in safename
+
+    def test_speed_is_positive(self, tmp_path):
+        obj = make_s3_object(FAKE_S3_PATH + "/product.zip", size=100_000_000)
+        creds, s3_resource = make_s3_client_mocks([obj])
+
+        output = str(tmp_path / f"{FAKE_SAFENAME}.zip")
+        conf = {**FAKE_CONF, "pre_spool": str(tmp_path)}
+
+        with (
+            patch("cdsodatacli.download._get_fresh_s3_client",
+                  return_value=(creds, s3_resource)),
+            patch("shutil.copy2"),
+            patch("os.remove"),
+            patch("os.chmod"),
+        ):
+            speed, elapsed, total_mb, status, _ = cds_s3_download_one_product(
+                FAKE_S3_PATH, FAKE_HEADER, output, conf
+            )
+
+        assert speed > 0
+        assert elapsed > 0
+        assert total_mb > 0
+
+    def test_tmp_file_moved_to_final_path(self, tmp_path):
+        """shutil.copy2 must be called with the .tmp source and final destination."""
+        obj = make_s3_object(FAKE_S3_PATH + "/product.zip")
+        creds, s3_resource = make_s3_client_mocks([obj])
+
+        output = str(tmp_path / f"{FAKE_SAFENAME}.zip")
+        conf = {**FAKE_CONF, "pre_spool": str(tmp_path)}
+        expected_tmp = os.path.join(str(tmp_path), f"{FAKE_SAFENAME}.zip.tmp")
+
+        with (
+            patch("cdsodatacli.download._get_fresh_s3_client",
+                  return_value=(creds, s3_resource)),
+            patch("shutil.copy2") as mock_copy,
+            patch("os.remove"),
+            patch("os.chmod"),
+        ):
+            cds_s3_download_one_product(FAKE_S3_PATH, FAKE_HEADER, output, conf)
+
+        mock_copy.assert_called_once_with(expected_tmp, output)
+
+    def test_credentials_deleted_after_success(self, tmp_path, patch_requests_delete):
+        obj = make_s3_object(FAKE_S3_PATH + "/product.zip")
+        creds, s3_resource = make_s3_client_mocks([obj])
+
+        output = str(tmp_path / f"{FAKE_SAFENAME}.zip")
+        conf = {**FAKE_CONF, "pre_spool": str(tmp_path)}
+
+        with (
+            patch("cdsodatacli.download._get_fresh_s3_client",
+                  return_value=(creds, s3_resource)),
+            patch("shutil.copy2"),
+            patch("os.remove"),
+            patch("os.chmod"),
+        ):
+            cds_s3_download_one_product(FAKE_S3_PATH, FAKE_HEADER, output, conf)
+
+        assert patch_requests_delete.call_count == 1
+        call_url = patch_requests_delete.call_args[0][0]
+        assert FAKE_ACCESS_ID in call_url
+
+
+class TestCdsS3DownloadMultiFile:
+    """Multi-file .SAFE product (directory tree)."""
+
+    def test_multifile_status_downloaded(self, tmp_path):
+        objects = [
+            make_s3_object(f"{FAKE_S3_PATH}/manifest.safe", size=1_000),
+            make_s3_object(f"{FAKE_S3_PATH}/measurement/s1a-iw-grd-vv.tiff",
+                           size=300_000_000),
+            make_s3_object(f"{FAKE_S3_PATH}/measurement/s1a-iw-grd-vh.tiff",
+                           size=200_000_000),
+        ]
+        creds, s3_resource = make_s3_client_mocks(objects)
+
+        output = str(tmp_path / FAKE_SAFENAME)
+        conf = {**FAKE_CONF, "pre_spool": str(tmp_path)}
+
+        with (
+            patch("cdsodatacli.download._get_fresh_s3_client",
+                  return_value=(creds, s3_resource)),
+            patch("os.makedirs"),
+        ):
+            speed, elapsed, total_mb, status, safename = cds_s3_download_one_product(
+                FAKE_S3_PATH, FAKE_HEADER, output, conf
+            )
+
+        assert status == "Downloaded"
+        assert speed > 0
+
+    def test_multifile_skips_folder_pseudo_objects(self, tmp_path):
+        """Objects whose key ends with '/' are folder markers and must not be downloaded."""
+        folder_obj = make_s3_object(f"{FAKE_S3_PATH}/", size=0)
+        real_obj = make_s3_object(f"{FAKE_S3_PATH}/manifest.safe", size=1_000)
+        creds, s3_resource = make_s3_client_mocks([folder_obj, real_obj])
+
+        bucket = s3_resource.Bucket.return_value
+        output = str(tmp_path / FAKE_SAFENAME)
+        conf = {**FAKE_CONF, "pre_spool": str(tmp_path)}
+
+        with (
+            patch("cdsodatacli.download._get_fresh_s3_client",
+                  return_value=(creds, s3_resource)),
+            patch("os.makedirs"),
+        ):
+            cds_s3_download_one_product(FAKE_S3_PATH, FAKE_HEADER, output, conf)
+
+        # download_file called once (only for manifest.safe, not the folder marker)
+        assert bucket.download_file.call_count == 1
+        downloaded_key = bucket.download_file.call_args[0][0]
+        assert not downloaded_key.endswith("/")
+
+
+class TestCdsS3DownloadErrors:
+    """Error paths: S3 not found, boto errors, move failure."""
+
+    def test_not_found_returns_notfound_status(self, tmp_path):
+        creds, s3_resource = make_s3_client_mocks([])  # empty object list
+        output = str(tmp_path / f"{FAKE_SAFENAME}.zip")
+        conf = {**FAKE_CONF, "pre_spool": str(tmp_path)}
+
+        with patch("cdsodatacli.download._get_fresh_s3_client",
+                   return_value=(creds, s3_resource)):
+            _, _, _, status, _ = cds_s3_download_one_product(
+                FAKE_S3_PATH, FAKE_HEADER, output, conf
+            )
+
+        assert status == "NotFound"
+
+    def test_boto_client_error_returns_s3error(self, tmp_path):
+        creds = FAKE_CREDENTIALS
+        s3_resource = MagicMock()
+        s3_resource.Bucket.side_effect = ClientError(
+            {"Error": {"Code": "403", "Message": "Forbidden"}}, "Bucket"
+        )
+        output = str(tmp_path / f"{FAKE_SAFENAME}.zip")
+        conf = {**FAKE_CONF, "pre_spool": str(tmp_path)}
+
+        with patch("cdsodatacli.download._get_fresh_s3_client",
+                   return_value=(creds, s3_resource)):
+            _, _, _, status, _ = cds_s3_download_one_product(
+                FAKE_S3_PATH, FAKE_HEADER, output, conf
+            )
+
+        assert status == "S3Error"
+
+    def test_botocore_error_returns_s3error(self, tmp_path):
+        creds = FAKE_CREDENTIALS
+        s3_resource = MagicMock()
+        s3_resource.Bucket.side_effect = BotoCoreError()
+        output = str(tmp_path / f"{FAKE_SAFENAME}.zip")
+        conf = {**FAKE_CONF, "pre_spool": str(tmp_path)}
+
+        with patch("cdsodatacli.download._get_fresh_s3_client",
+                   return_value=(creds, s3_resource)):
+            _, _, _, status, _ = cds_s3_download_one_product(
+                FAKE_S3_PATH, FAKE_HEADER, output, conf
+            )
+
+        assert status == "S3Error"
+
+    def test_tmp_file_cleaned_up_on_s3error(self, tmp_path):
+        """Leftover .tmp must be removed when a S3 error occurs mid-download."""
+        creds = FAKE_CREDENTIALS
+        s3_resource = MagicMock()
+        # Bucket() succeeds, but download_file raises ClientError
+        bucket = MagicMock()
+        obj = make_s3_object(FAKE_S3_PATH + "/product.zip")
+        bucket.objects.filter.return_value = [obj]
+        bucket.download_file.side_effect = ClientError(
+            {"Error": {"Code": "500", "Message": "Internal"}}, "download_file"
+        )
+        s3_resource.Bucket.return_value = bucket
+
+        output = str(tmp_path / f"{FAKE_SAFENAME}.zip")
+        tmp_file = os.path.join(str(tmp_path), f"{FAKE_SAFENAME}.zip.tmp")
+        conf = {**FAKE_CONF, "pre_spool": str(tmp_path)}
+
+        # Create a dummy .tmp to simulate partial download
+        open(tmp_file, "w").close()
+
+        with patch("cdsodatacli.download._get_fresh_s3_client",
+                   return_value=(creds, s3_resource)):
+            cds_s3_download_one_product(FAKE_S3_PATH, FAKE_HEADER, output, conf)
+
+        assert not os.path.exists(tmp_file), ".tmp file should have been cleaned up"
+
+    def test_move_error_returns_moveerror_status(self, tmp_path):
+        obj = make_s3_object(FAKE_S3_PATH + "/product.zip")
+        creds, s3_resource = make_s3_client_mocks([obj])
+
+        output = str(tmp_path / f"{FAKE_SAFENAME}.zip")
+        conf = {**FAKE_CONF, "pre_spool": str(tmp_path)}
+
+        with (
+            patch("cdsodatacli.download._get_fresh_s3_client",
+                  return_value=(creds, s3_resource)),
+            patch("shutil.copy2", side_effect=OSError("disk full")),
+            patch("os.remove"),
+        ):
+            _, _, _, status, _ = cds_s3_download_one_product(
+                FAKE_S3_PATH, FAKE_HEADER, output, conf
+            )
+
+        assert status == "MoveError"
+
+    def test_credentials_deleted_even_on_error(self, tmp_path, patch_requests_delete):
+        """Credential cleanup must happen regardless of download outcome."""
+        creds, s3_resource = make_s3_client_mocks([])  # triggers NotFound
+
+        output = str(tmp_path / f"{FAKE_SAFENAME}.zip")
+        conf = {**FAKE_CONF, "pre_spool": str(tmp_path)}
+
+        with patch("cdsodatacli.download._get_fresh_s3_client",
+                   return_value=(creds, s3_resource)):
+            cds_s3_download_one_product(FAKE_S3_PATH, FAKE_HEADER, output, conf)
+
+        assert patch_requests_delete.call_count == 1
+
+
+# ===========================================================================
+# Part 2 — download_list_product_multithread_v4 integration tests
+# ===========================================================================
+
+class TestV4InputValidation:
+    """Input contracts."""
+
+    def test_mismatched_lengths_raise(self):
+        # S3Path column absent — KeyError fires inside the function before
+        # any network call is made, satisfying the input-contract test.
+        df = pd.DataFrame({
+            "safename": ["SAFE_A", "SAFE_B"],
+            "id": ["id0", "id1"],
+            # "S3Path" intentionally absent
+        })
+        with pytest.raises((AssertionError, KeyError)):
+            download_list_product_multithread_v4(
+                df, "/fake/out", account_group="logins"
+            )
+
+    def test_status_column_created_if_absent(self, patch_filter):
+        """If inputdf has no 'status' column, v4 must add it silently."""
+        safenames = ["SAFE_A"]
+        df = pd.DataFrame({
+            "safename": safenames,
+            "S3Path": ["Sentinel-1/SAR/GRD/2022/05/03/SAFE_A.SAFE"],
+            "id": ["id0"],
+            # no 'status' column
+        })
+
+        def _all_done(cpt, df_in, outputdir, force_download, cdsodatacli_conf,
+                      extension=""):
+            # return empty so the while loop exits immediately
+            empty = df_in.iloc[:0].copy()
+            return empty, cpt
+
+        patch_filter.side_effect = _all_done
+
+        # Should not raise even though 'status' is missing in input
+        with patch("cdsodatacli.download.get_sessions_download_available"):
+            download_list_product_multithread_v4(
+                df, "/fake/out", account_group="logins"
+            )
+
+
+class TestV4AllSuccessful:
+    """Happy path: every product downloads with status 'Downloaded'."""
+
+    def test_returns_dataframe(self):
+        safenames = ["SAFE_A", "SAFE_B"]
+        inputdf = make_inputdf(safenames)
+
+        with (
+            patch("cdsodatacli.download.get_sessions_download_available",
+                  return_value=make_downloadable_df(safenames)),
+            patch("cdsodatacli.download.cds_s3_download_one_product",
+                  side_effect=[make_s3_result(s) for s in safenames]),
+        ):
+            result = download_list_product_multithread_v4(
+                inputdf, "/fake/out", account_group="logins"
+            )
+
+        assert isinstance(result, pd.DataFrame)
+
+    def test_all_status_1_on_downloaded(self):
+        safenames = ["SAFE_A", "SAFE_B"]
+        inputdf = make_inputdf(safenames)
+
+        def mock_s3_worker(s3_path, header, output_path, conf):
+            safename = os.path.basename(output_path)
+            return make_s3_result(safename)
+
+        with (
+            patch("cdsodatacli.download.get_sessions_download_available",
+                  return_value=make_downloadable_df(safenames)),
+            patch("cdsodatacli.download.cds_s3_download_one_product",
+                  side_effect=mock_s3_worker),
+        ):
+            result = download_list_product_multithread_v4(
+                inputdf, "/fake/out", account_group="logins"
+            )
+
+        assert (result["status"] == 1).all()
+
+    def test_ok_status_meaning_also_sets_status_1(self):
+        """'OK' is accepted as a success status_meaning in v4 (legacy compat)."""
+        safenames = ["SAFE_A"]
+        inputdf = make_inputdf(safenames)
+
+        with (
+            patch("cdsodatacli.download.get_sessions_download_available",
+                  return_value=make_downloadable_df(safenames)),
+            patch("cdsodatacli.download.cds_s3_download_one_product",
+                  return_value=make_s3_result("SAFE_A", status="OK")),
+        ):
+            result = download_list_product_multithread_v4(
+                inputdf, "/fake/out", account_group="logins"
+            )
+
+        assert result.loc[result["safe"] == "SAFE_A", "status"].iloc[0] == 1
+
+
+class TestV4DownloadErrors:
+    """Non-OK status_meaning and unhandled exceptions."""
+
+    def test_notfound_marks_status_minus1(self):
+        safenames = ["SAFE_MISSING"]
+        inputdf = make_inputdf(safenames)
+
+        with (
+            patch("cdsodatacli.download.get_sessions_download_available",
+                  return_value=make_downloadable_df(safenames)),
+            patch("cdsodatacli.download.cds_s3_download_one_product",
+                  return_value=make_s3_result("SAFE_MISSING", status="NotFound",
+                                              speed=np.nan)),
+        ):
+            result = download_list_product_multithread_v4(
+                inputdf, "/fake/out", account_group="logins"
+            )
+
+        assert result.loc[result["safe"] == "SAFE_MISSING", "status"].iloc[0] == -1
+
+    def test_s3error_marks_status_minus1(self):
+        safenames = ["SAFE_ERR"]
+        inputdf = make_inputdf(safenames)
+
+        with (
+            patch("cdsodatacli.download.get_sessions_download_available",
+                  return_value=make_downloadable_df(safenames)),
+            patch("cdsodatacli.download.cds_s3_download_one_product",
+                  return_value=make_s3_result("SAFE_ERR", status="S3Error",
+                                              speed=np.nan)),
+        ):
+            result = download_list_product_multithread_v4(
+                inputdf, "/fake/out", account_group="logins"
+            )
+
+        assert result.loc[result["safe"] == "SAFE_ERR", "status"].iloc[0] == -1
+
+    def test_unhandled_exception_marks_status_minus1(self):
+        safenames = ["SAFE_CRASH"]
+        inputdf = make_inputdf(safenames)
+
+        with (
+            patch("cdsodatacli.download.get_sessions_download_available",
+                  return_value=make_downloadable_df(safenames)),
+            patch("cdsodatacli.download.cds_s3_download_one_product",
+                  side_effect=RuntimeError("unexpected crash")),
+        ):
+            result = download_list_product_multithread_v4(
+                inputdf, "/fake/out", account_group="logins"
+            )
+
+        assert result.loc[result["safe"] == "SAFE_CRASH", "status"].iloc[0] == -1
+
+    def test_one_failure_does_not_abort_others(self):
+        safenames = ["SAFE_OK", "SAFE_FAIL"]
+        inputdf = make_inputdf(safenames)
+
+        def sessions_side_effect(conf, subset, **kw):
+            pending = subset["safe"].tolist()
+            return make_downloadable_df([s for s in safenames if s in pending])
+
+        def worker(s3_path, header, output_path, conf):
+            safename = os.path.basename(output_path)
+            if safename == "SAFE_FAIL":
+                return make_s3_result("SAFE_FAIL", status="S3Error", speed=np.nan)
+            return make_s3_result(safename)
+
+        with (
+            patch("cdsodatacli.download.get_sessions_download_available",
+                  side_effect=sessions_side_effect),
+            patch("cdsodatacli.download.cds_s3_download_one_product",
+                  side_effect=worker),
+        ):
+            result = download_list_product_multithread_v4(
+                inputdf, "/fake/out", account_group="logins"
+            )
+
+        assert result.loc[result["safe"] == "SAFE_OK", "status"].iloc[0] == 1
+        assert result.loc[result["safe"] == "SAFE_FAIL", "status"].iloc[0] == -1
+
+    def test_all_failures_loop_terminates(self):
+        """While loop must exit even if every product fails (no infinite loop)."""
+        safenames = ["SAFE_A", "SAFE_B", "SAFE_C"]
+        inputdf = make_inputdf(safenames)
+
+        def failing_worker(s3_path, header, output_path, conf):
+            safename = os.path.basename(output_path)
+            return make_s3_result(safename, status="S3Error", speed=np.nan)
+
+        with (
+            patch("cdsodatacli.download.get_sessions_download_available",
+                  return_value=make_downloadable_df(safenames)),
+            patch("cdsodatacli.download.cds_s3_download_one_product",
+                  side_effect=failing_worker),
+        ):
+            result = download_list_product_multithread_v4(
+                inputdf, "/fake/out", account_group="logins"
+            )
+
+        assert (result["status"] != 0).all()
+
+
+class TestV4NoDuplicateDownload:
+    """Same safename must not be submitted twice concurrently."""
+
+    def test_duplicate_safename_submitted_only_once(self):
+        safenames = ["SAFE_A", "SAFE_A"]
+        inputdf = make_inputdf(safenames)
+        submission_count = {"n": 0}
+
+        def tracking_worker(s3_path, header, output_path, conf):
+            submission_count["n"] += 1
+            return make_s3_result("SAFE_A")
+
+        with (
+            patch("cdsodatacli.download.get_sessions_download_available",
+                  return_value=make_downloadable_df(safenames)),
+            patch("cdsodatacli.download.cds_s3_download_one_product",
+                  side_effect=tracking_worker),
+        ):
+            download_list_product_multithread_v4(
+                inputdf, "/fake/out", account_group="logins"
+            )
+
+        assert submission_count["n"] == 1
+
+
+class TestV4AllAlreadyPresent:
+    """All products already on disk — nothing to download."""
+
+    def test_empty_df2_skips_sessions(self, patch_filter):
+        def _all_archived(cpt, df_in, outputdir, force_download,
+                          cdsodatacli_conf, extension=""):
+            cpt["archived_product"] = len(df_in)
+            empty = df_in.iloc[:0].copy()
+            return empty, cpt
+
+        patch_filter.side_effect = _all_archived
+
+        with patch("cdsodatacli.download.get_sessions_download_available") as mock_sess:
+            download_list_product_multithread_v4(
+                make_inputdf(["SAFE_A"]), "/fake/out", account_group="logins"
+            )
+
+        mock_sess.assert_not_called()
+
+
+class TestV4NoSession:
+    """get_sessions_download_available returns empty — should wait and retry."""
+
+    def test_sleeps_when_no_session(self):
+        safenames = ["SAFE_A"]
+        inputdf = make_inputdf(safenames)
+        call_count = {"n": 0}
+
+        def sessions_side_effect(*a, **kw):
+            call_count["n"] += 1
+            if call_count["n"] < 3:
+                return make_downloadable_df([])
+            return make_downloadable_df(safenames)
+
+        def s3_worker(s3_path, header, output_path, conf):
+            return make_s3_result(os.path.basename(output_path))
+
+        with (
+            patch("cdsodatacli.download.get_sessions_download_available",
+                  side_effect=sessions_side_effect),
+            patch("cdsodatacli.download.cds_s3_download_one_product",
+                  side_effect=s3_worker),
+            patch("cdsodatacli.download.time.sleep") as mock_sleep,
+        ):
+            download_list_product_multithread_v4(
+                inputdf, "/fake/out", account_group="logins"
+            )
+
+        assert mock_sleep.call_count >= 2
+
+    def test_sleep_duration_is_5_seconds(self):
+        safenames = ["SAFE_A"]
+        inputdf = make_inputdf(safenames)
+        call_count = {"n": 0}
+
+        def sessions_side_effect(*a, **kw):
+            call_count["n"] += 1
+            if call_count["n"] < 2:
+                return make_downloadable_df([])
+            return make_downloadable_df(safenames)
+
+        def s3_worker(s3_path, header, output_path, conf):
+            return make_s3_result(os.path.basename(output_path))
+
+        with (
+            patch("cdsodatacli.download.get_sessions_download_available",
+                  side_effect=sessions_side_effect),
+            patch("cdsodatacli.download.cds_s3_download_one_product",
+                  side_effect=s3_worker),
+            patch("cdsodatacli.download.time.sleep") as mock_sleep,
+        ):
+            download_list_product_multithread_v4(
+                inputdf, "/fake/out", account_group="logins"
+            )
+
+        for c in mock_sleep.call_args_list:
+            assert c.args[0] == 5
+
+
+class TestV4FilterCalledWithExtensionEmpty:
+    """v4 passes extension='' to filter_product_already_present (SAFE dirs, not .zip)."""
+
+    def test_filter_called_with_empty_extension(self, patch_filter):
+        safenames = ["SAFE_A"]
+        inputdf = make_inputdf(safenames)
+
+        def _capture(cpt, df_in, outputdir, force_download,
+                     cdsodatacli_conf, extension=""):
+            _capture.extension_used = extension
+            empty = df_in.iloc[:0].copy()
+            return empty, cpt
+
+        _capture.extension_used = None
+        patch_filter.side_effect = _capture
+
+        with patch("cdsodatacli.download.get_sessions_download_available"):
+            download_list_product_multithread_v4(
+                inputdf, "/fake/out", account_group="logins"
+            )
+
+        assert _capture.extension_used == ""
+
+
+class TestV4Concurrency:
+    """Race condition and true parallelism checks."""
+
+    def test_two_products_can_run_concurrently(self):
+        safenames = ["SAFE_X", "SAFE_Y"]
+        inputdf = make_inputdf(safenames)
+        active = {"count": 0, "max": 0}
+        lock = threading.Lock()
+
+        def concurrent_worker(s3_path, header, output_path, conf):
+            safename = os.path.basename(output_path)
+            with lock:
+                active["count"] += 1
+                active["max"] = max(active["max"], active["count"])
+            time.sleep(0.05)
+            with lock:
+                active["count"] -= 1
+            return make_s3_result(safename)
+
+        with (
+            patch("cdsodatacli.download.get_sessions_download_available",
+                  return_value=make_downloadable_df(safenames)),
+            patch("cdsodatacli.download.cds_s3_download_one_product",
+                  side_effect=concurrent_worker),
+        ):
+            result = download_list_product_multithread_v4(
+                inputdf, "/fake/out", account_group="logins"
+            )
+
+        assert (result["status"] == 1).all()
+        assert active["max"] >= 2
+
+    def test_slow_product_not_resubmitted(self):
+        """A product still in flight must not be re-submitted in the next loop.
+
+        The barrier is released by a daemon thread after a short delay so it
+        fires independently of the while-loop progression — avoiding the
+        deadlock where the worker waits for the barrier and the barrier is only
+        set inside sessions_side_effect which itself only runs after the worker
+        finishes.
+        """
+        safenames = ["SAFE_SLOW"]
+        inputdf = make_inputdf(safenames)
+        submission_count = {"n": 0}
+        barrier = threading.Event()
+
+        # Release the barrier from a background thread after 0.2 s so the
+        # slow worker can finish regardless of how many loop iterations occur.
+        def _release():
+            time.sleep(0.2)
+            barrier.set()
+
+        threading.Thread(target=_release, daemon=True).start()
+
+        def slow_worker(s3_path, header, output_path, conf):
+            submission_count["n"] += 1
+            assert barrier.wait(timeout=5), "barrier was never released"
+            return make_s3_result("SAFE_SLOW")
+
+        with (
+            patch("cdsodatacli.download.get_sessions_download_available",
+                  return_value=make_downloadable_df(safenames)),
+            patch("cdsodatacli.download.cds_s3_download_one_product",
+                  side_effect=slow_worker),
+        ):
+            download_list_product_multithread_v4(
+                inputdf, "/fake/out", account_group="logins"
+            )
+
+        assert submission_count["n"] == 1

--- a/tests/test_get_ids_safe_iterative.py
+++ b/tests/test_get_ids_safe_iterative.py
@@ -187,4 +187,4 @@ def test_add_ids_to_listing_with_email_password(sample_listing, tmp_path, sample
         call_kwargs = mocked_api.call_args
         assert call_kwargs.kwargs.get("email") == "user@example.com"
         assert call_kwargs.kwargs.get("password") == "secret"
-        assert "conf" not in call_kwargs.kwargs
+        assert "conf" in call_kwargs.kwargs

--- a/tests/test_get_ids_safe_iterative.py
+++ b/tests/test_get_ids_safe_iterative.py
@@ -24,12 +24,19 @@ def sample_listing(tmp_path):
     return str(p)
 
 
+@pytest.fixture
+def sample_conf():
+    """Creates a minimal dummy conf dict matching cdsodatacli's expected structure."""
+    return {
+        "list_sar_unit_private_data": [],
+    }
+
+
 @skip_in_ci
-def test_add_ids_to_listing_iterative_full_success(sample_listing, tmp_path):
+def test_add_ids_to_listing_iterative_full_success(sample_listing, tmp_path, sample_conf):
     """Test case where all IDs are found in the first iteration."""
     output_path = str(tmp_path / "final_output.csv")
 
-    # Prepare mocked response from the API wrapper
     mock_df = pd.DataFrame(
         {
             "safename": [
@@ -45,7 +52,9 @@ def test_add_ids_to_listing_iterative_full_success(sample_listing, tmp_path):
         "cdsodatacli.download.add_missing_cdse_hash_ids_in_listing",
         return_value=mock_df,
     ):
-        result_file = add_ids_to_listing_iterative(sample_listing, output_path)
+        result_file = add_ids_to_listing_iterative(
+            sample_listing, output_path, conf=sample_conf
+        )
 
         assert os.path.exists(result_file)
         df_out = pd.read_csv(result_file, names=["id", "safename"])
@@ -54,7 +63,7 @@ def test_add_ids_to_listing_iterative_full_success(sample_listing, tmp_path):
 
 
 @skip_in_ci
-def test_add_ids_to_listing_iterative_multi_step(sample_listing, tmp_path):
+def test_add_ids_to_listing_iterative_multi_step(sample_listing, tmp_path, sample_conf):
     """Test case where IDs are found across multiple loops (iterations)."""
     output_path = str(tmp_path / "multi_step_output.csv")
 
@@ -78,7 +87,9 @@ def test_add_ids_to_listing_iterative_multi_step(sample_listing, tmp_path):
     ) as mocked_api:
         mocked_api.side_effect = [mock_response_1, mock_response_2]
 
-        result_file = add_ids_to_listing_iterative(sample_listing, output_path)
+        result_file = add_ids_to_listing_iterative(
+            sample_listing, output_path, conf=sample_conf
+        )
 
         df_out = pd.read_csv(result_file, names=["id", "safename"])
         assert len(df_out) == 3
@@ -87,7 +98,7 @@ def test_add_ids_to_listing_iterative_multi_step(sample_listing, tmp_path):
 
 
 @skip_in_ci
-def test_add_ids_to_listing_no_progress_break(sample_listing, tmp_path):
+def test_add_ids_to_listing_no_progress_break(sample_listing, tmp_path, sample_conf):
     """Test that the loop breaks if no new IDs are found to avoid infinite loops."""
     output_path = str(tmp_path / "break_output.csv")
 
@@ -98,7 +109,9 @@ def test_add_ids_to_listing_no_progress_break(sample_listing, tmp_path):
         "cdsodatacli.download.add_missing_cdse_hash_ids_in_listing",
         return_value=empty_df,
     ):
-        result_file = add_ids_to_listing_iterative(sample_listing, output_path)
+        result_file = add_ids_to_listing_iterative(
+            sample_listing, output_path, conf=sample_conf
+        )
 
         df_out = pd.read_csv(result_file, names=["id", "safename"])
         # IDs should be NaN because nothing was found, but the script should have finished
@@ -106,14 +119,14 @@ def test_add_ids_to_listing_no_progress_break(sample_listing, tmp_path):
 
 
 @skip_in_ci
-def test_add_ids_to_listing_file_not_found():
+def test_add_ids_to_listing_file_not_found(sample_conf):
     """Test behavior when the input file does not exist."""
     with pytest.raises(FileNotFoundError):
-        add_ids_to_listing_iterative("non_existent_file.txt")
+        add_ids_to_listing_iterative("non_existent_file.txt", conf=sample_conf)
 
 
 @skip_in_ci
-def test_add_ids_to_listing_duplicates_in_api(sample_listing, tmp_path):
+def test_add_ids_to_listing_duplicates_in_api(sample_listing, tmp_path, sample_conf):
     """Test that the script handles duplicates returned by the API correctly."""
     output_path = str(tmp_path / "dedup_output.csv")
 
@@ -132,8 +145,44 @@ def test_add_ids_to_listing_duplicates_in_api(sample_listing, tmp_path):
         "cdsodatacli.download.add_missing_cdse_hash_ids_in_listing",
         return_value=mock_df,
     ):
-        result_file = add_ids_to_listing_iterative(sample_listing, output_path)
+        result_file = add_ids_to_listing_iterative(
+            sample_listing, output_path, conf=sample_conf
+        )
         df_out = pd.read_csv(result_file, names=["id", "safename"])
 
         # Should still correspond to input length (3) even if API was weird
         assert len(df_out) == 3
+
+
+@skip_in_ci
+def test_add_ids_to_listing_with_email_password(sample_listing, tmp_path, sample_conf):
+    """Test that email and password are forwarded to the underlying API call."""
+    output_path = str(tmp_path / "auth_output.csv")
+
+    mock_df = pd.DataFrame(
+        {
+            "safename": ["S1A_IW_GRDH_1SDV_20220503T000000"],
+            "id": ["uuid0"],
+        }
+    )
+
+    with patch(
+        "cdsodatacli.download.add_missing_cdse_hash_ids_in_listing",
+        return_value=mock_df,
+    ) as mocked_api:
+        # Only one SAFE in the listing for this test
+        p = tmp_path / "single_safe.txt"
+        p.write_text("S1A_IW_GRDH_1SDV_20220503T000000")
+
+        add_ids_to_listing_iterative(
+            str(p),
+            output_path,
+            email="user@example.com",
+            password="secret",
+            conf=sample_conf,
+        )
+
+        call_kwargs = mocked_api.call_args
+        assert call_kwargs.kwargs.get("email") == "user@example.com"
+        assert call_kwargs.kwargs.get("password") == "secret"
+        assert "conf" not in call_kwargs.kwargs

--- a/tests/test_get_ids_safe_iterative.py
+++ b/tests/test_get_ids_safe_iterative.py
@@ -33,7 +33,9 @@ def sample_conf():
 
 
 @skip_in_ci
-def test_add_ids_to_listing_iterative_full_success(sample_listing, tmp_path, sample_conf):
+def test_add_ids_to_listing_iterative_full_success(
+    sample_listing, tmp_path, sample_conf
+):
     """Test case where all IDs are found in the first iteration."""
     output_path = str(tmp_path / "final_output.csv")
 


### PR DESCRIPTION
## Description

the goal is to replace the current "zipper" download solution by `S3` (described here https://documentation.dataspace.copernicus.eu/APIs/S3.html)
We expect better download performances and better robustness (less corrupted downloads).
We will have to keep the 2 solutions for comparison.
access token is probably useless for S3 download, but I don"t want to duplicate the method `session.py get_sessions_download_available()` so for now I keep it like it is.

- [x] add the download method using S3
- [x] update config.yml to have the keys expected (s3_endpoint , ...)
- [x] generate access/secret S3 https://eodata-s3keysmanager.dataspace.copernicus.eu/ (first intention is to go for a live S3 access creation, we will see whether it is relevant or not)
- [x] add new dependencies (eg `boto3`, ...)
- [x] list of SAR units that are private in CDSE is now coming from conf file.
- [x] do the link between `download_list_product_multithread_v4` and `cds_s3_download_one_product`
- [x] make sure the S3 path is retrieve from the CDS query
- [x] add a unit test for this new method
- [x] test end2end
- [x] compare performances: x5 faster for `s3endpoint` compared to existing legacy `zipper` solution.
- [x] unit test successful
- [x] doc updated and successfully compiled

test with
```bash
(dev) :~/git/cdsodatacli$ python cdsodatacli/scripts/download_multithread_one_account_deamon.py --cdsodatacli_conf_file cdsodatacli/localconfig.yml --outputdir /tmp/ --listing /tmp/dummy_iw_ocn_listing_with_ids.txt --logingroup groupdev
```

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/cdsodatacli/cdsodatacli/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/cdsodatacli/cdsodatacli/blob/master/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
