### PR TITLE
Add script to do matching S1 product types (SLC<->GRD or SLC<->OCN or ...)

### DIFF
--- a/cdsodatacli/query.py
+++ b/cdsodatacli/query.py
@@ -711,7 +711,7 @@ def fetch_one_url(url, cpt, index, cache_dir, headers=None):
             cpt["product_proposed_by_CDS"] += len(collected_data["Name"])
             collected_data["id_original_query"] = index
             if len(collected_data) == DEFAULT_TOP_ROWS_PER_QUERY:
-                logging.warning(
+                logger.warning(
                     "%i products found in a single OData query (max is %s).",
                     len(collected_data),
                     DEFAULT_TOP_ROWS_PER_QUERY,

--- a/cdsodatacli/query.py
+++ b/cdsodatacli/query.py
@@ -433,7 +433,7 @@ def apply_slicing_time_to_gdf(gdf, timedelta_slice=None):
                 if not gdf_slice.empty:
                     gdf_slices.append(gdf_slice)
                 slice_begin = slice_end
-    if len(gdf_slices)>0:
+    if len(gdf_slices) > 0:
         gdf_norm = gpd.GeoDataFrame(
             pd.concat(gdf_slices, ignore_index=False), crs=gdf_slices[0].crs
         )

--- a/cdsodatacli/query.py
+++ b/cdsodatacli/query.py
@@ -432,9 +432,12 @@ def apply_slicing_time_to_gdf(gdf, timedelta_slice=None):
                 if not gdf_slice.empty:
                     gdf_slices.append(gdf_slice)
                 slice_begin = slice_end
-    gdf_norm = gpd.GeoDataFrame(
-        pd.concat(gdf_slices, ignore_index=False), crs=gdf_slices[0].crs
-    )
+    if len(gdf_slices)>0:
+        gdf_norm = gpd.GeoDataFrame(
+            pd.concat(gdf_slices, ignore_index=False), crs=gdf_slices[0].crs
+        )
+    else:
+        gdf_norm = gdf
     return gdf_norm
 
 
@@ -533,9 +536,11 @@ def normalize_gdf(
     end_time = time.time()
     processing_time = end_time - start_time
     logging.info(f"processing time to normalize the GeoDataFrame :{processing_time}s")
+
     gdf_norm_sliced = apply_slicing_time_to_gdf(
-        gdf=norm_gdf, timedelta_slice=timedelta_slice
-    )
+            gdf=norm_gdf, timedelta_slice=timedelta_slice
+        )
+
     return gdf_norm_sliced
 
 

--- a/cdsodatacli/scripts/match_s1_product_types.py
+++ b/cdsodatacli/scripts/match_s1_product_types.py
@@ -19,6 +19,7 @@ ODATA_URL = "https://catalogue.dataspace.copernicus.eu/odata/v1/Products"
 
 VALID_PRODUCT_TYPES = ["GRDH", "GRDM", "SLC_", "OCN_", "RAW_"]
 
+
 # ── LOGGING SETUP ────────────────────────────────────────────────────────────
 def setup_logger(verbose: bool = False) -> logging.Logger:
     logger = logging.getLogger("s1_matchup")
@@ -28,8 +29,7 @@ def setup_logger(verbose: bool = False) -> logging.Logger:
     handler.setLevel(logging.DEBUG if verbose else logging.INFO)
 
     formatter = logging.Formatter(
-        fmt="%(asctime)s [%(levelname)s] %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S"
+        fmt="%(asctime)s [%(levelname)s] %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
     )
     handler.setFormatter(formatter)
     logger.addHandler(handler)
@@ -41,7 +41,7 @@ def parse_start_time(product_name: str) -> datetime | None:
     """Extract and parse the start timestamp from a Sentinel-1 product name."""
     try:
         inst = ExplodeSAFE(product_name)  # Validate format and raise if not Sentinel-1
-        return inst.startdate             # Already a datetime object
+        return inst.startdate  # Already a datetime object
     except (IndexError, ValueError):
         return None
 
@@ -49,8 +49,11 @@ def parse_start_time(product_name: str) -> datetime | None:
 MAX_DELTA_SECONDS = 8
 
 
-def closest_in_time(reference_dt: datetime, candidates: list[dict]) -> tuple[dict, float]:
+def closest_in_time(
+    reference_dt: datetime, candidates: list[dict]
+) -> tuple[dict, float]:
     """Return (candidate, delta_seconds) for the product closest in time to reference_dt."""
+
     def time_delta(prod):
         dt = parse_start_time(prod["Name"])
         if dt is None:
@@ -77,13 +80,17 @@ def find_product_for_safe(
         clean_id = source_id.replace(".SAFE", "").replace("_COG", "")
         parts = clean_id.split("_")
 
-        platform     = parts[0]  # e.g. S1A
-        start_time   = parts[4]  # e.g. 20230726T071112
+        platform = parts[0]  # e.g. S1A
+        start_time = parts[4]  # e.g. 20230726T071112
         datatake_hex = parts[7]  # e.g. 05F692
 
         # Normalise target type: pad to 4 chars with trailing underscore if needed
         # so "GRDH" stays "GRDH", "SLC_" stays "SLC_", etc.
-        type_token = target_type.rstrip("_").ljust(4, "_") if len(target_type) < 4 else target_type
+        type_token = (
+            target_type.rstrip("_").ljust(4, "_")
+            if len(target_type) < 4
+            else target_type
+        )
 
         query_filter = (
             f"startswith(Name,'{platform}') and "
@@ -100,7 +107,7 @@ def find_product_for_safe(
             return {
                 "source_id": source_id,
                 "status": "error",
-                "note": f"HTTP {resp.status_code}: {resp.text[:200]}"
+                "note": f"HTTP {resp.status_code}: {resp.text[:200]}",
             }
 
         products = resp.json().get("value", [])
@@ -109,7 +116,7 @@ def find_product_for_safe(
             return {
                 "source_id": source_id,
                 "status": "not_found",
-                "note": f"No {target_type} product found for DataTake {datatake_hex}"
+                "note": f"No {target_type} product found for DataTake {datatake_hex}",
             }
 
         # ── Match strategy ───────────────────────────────────────────────────
@@ -140,8 +147,9 @@ def find_product_for_safe(
                 }
             match_method = "closest_in_time"
             logger.debug(
-                "No exact timestamp match; picked closest product "
-                "(delta=%.0fs): %s", delta, match["Name"]
+                "No exact timestamp match; picked closest product " "(delta=%.0fs): %s",
+                delta,
+                match["Name"],
             )
 
         return {
@@ -150,7 +158,7 @@ def find_product_for_safe(
             "target_name": match["Name"],
             "target_type": target_type,
             "match_method": match_method,
-            "size_mb": round(match["ContentLength"] / 1024 ** 2, 2),
+            "size_mb": round(match["ContentLength"] / 1024**2, 2),
             "download_url": (
                 f"https://download.dataspace.copernicus.eu"
                 f"/odata/v1/Products({match['Id']})/$value"
@@ -172,7 +180,8 @@ def entrypoint(
 ) -> list[dict]:
     logger.info(
         "Starting matchup: %d product(s) → target type '%s'",
-        len(safe_list), target_type
+        len(safe_list),
+        target_type,
     )
     results = []
     delta_distribution: defaultdict[int, int] = defaultdict(int)
@@ -186,13 +195,17 @@ def entrypoint(
                 continue
 
             logger.debug("Processing %s", safe_id)
-            res = find_product_for_safe(safe_id, target_type, logger, delta_distribution)
+            res = find_product_for_safe(
+                safe_id, target_type, logger, delta_distribution
+            )
             results.append(res)
 
             if "target_name" in res:
                 logger.debug(
                     "  ✓ Found (%s): %s  [%.1f MB]",
-                    res["match_method"], res["target_name"], res["size_mb"]
+                    res["match_method"],
+                    res["target_name"],
+                    res["size_mb"],
                 )
             else:
                 logger.debug(
@@ -202,7 +215,9 @@ def entrypoint(
             time.sleep(0.5)  # Be polite to the OData endpoint
 
     except KeyboardInterrupt:
-        logger.warning("Interrupted by user after %d product(s) processed.", len(results))
+        logger.warning(
+            "Interrupted by user after %d product(s) processed.", len(results)
+        )
 
     # ── Write results ────────────────────────────────────────────────────────
     output_path = Path(output_filename)
@@ -213,13 +228,16 @@ def entrypoint(
             else:
                 fh.write(f"# NOT_FOUND: {r['source_id']} — {r.get('note', '')}\n")
 
-    found     = sum(1 for r in results if "target_name" in r)
+    found = sum(1 for r in results if "target_name" in r)
     not_found = sum(1 for r in results if r.get("status") == "not_found")
-    errors    = sum(1 for r in results if r.get("status") == "error")
+    errors = sum(1 for r in results if r.get("status") == "error")
 
     logger.info(
         "Done — %d found, %d not found, %d errors. Results → %s",
-        found, not_found, errors, output_path.resolve()
+        found,
+        not_found,
+        errors,
+        output_path.resolve(),
     )
 
     # ── Delta distribution ────────────────────────────────────────────────────
@@ -227,7 +245,7 @@ def entrypoint(
         logger.info("Delta-time distribution (seconds → count):")
         for delta_s, count in sorted(delta_distribution.items()):
             label = f"{delta_s}s" if delta_s > 0 else "exact"
-            flag  = "  ← above threshold" if delta_s > MAX_DELTA_SECONDS else ""
+            flag = "  ← above threshold" if delta_s > MAX_DELTA_SECONDS else ""
             logger.info("  %6s : %d%s", label, count, flag)
 
     return results
@@ -249,7 +267,7 @@ Examples:
 
   # Enable verbose/debug logging
   python s1_matchup.py --prodtype OCN_ --input-listing list.txt --verbose
-        """
+        """,
     )
 
     source_group = parser.add_mutually_exclusive_group(required=True)
@@ -284,7 +302,8 @@ Examples:
         help="Enable dev mode with reduced number of SAFE to treat.",
     )
     parser.add_argument(
-        "--verbose", "-v",
+        "--verbose",
+        "-v",
         action="store_true",
         help="Enable DEBUG-level logging.",
     )
@@ -297,7 +316,7 @@ def load_listing(filepath: str, logger: logging.Logger) -> list[str]:
     if not path.exists():
         logger.error("Input listing file not found: %s", filepath)
         raise SystemExit(1)
-    lines = [l.strip() for l in path.read_text().splitlines() if l.strip()]
+    lines = [lili.strip() for lili in path.read_text().splitlines() if lili.strip()]
     logger.info("Loaded %d product ID(s) from %s", len(lines), filepath)
     return lines
 

--- a/cdsodatacli/scripts/match_s1_product_types.py
+++ b/cdsodatacli/scripts/match_s1_product_types.py
@@ -38,11 +38,10 @@ def setup_logger(verbose: bool = False) -> logging.Logger:
 
 # ── HELPERS ──────────────────────────────────────────────────────────────────
 def parse_start_time(product_name: str) -> datetime | None:
-    """Extract and parse the start timestamp from a Sentinel-1 product name."""
     try:
-        inst = ExplodeSAFE(product_name)  # Validate format and raise if not Sentinel-1
-        return inst.startdate  # Already a datetime object
-    except (IndexError, ValueError):
+        inst = ExplodeSAFE(product_name)
+        return inst.startdate
+    except (IndexError, ValueError, AttributeError):  # Added AttributeError
         return None
 
 

--- a/cdsodatacli/scripts/match_s1_product_types.py
+++ b/cdsodatacli/scripts/match_s1_product_types.py
@@ -320,8 +320,7 @@ def load_listing(filepath: str, logger: logging.Logger) -> list[str]:
     return lines
 
 
-# ── MAIN ──────────────────────────────────────────────────────────────────────
-if __name__ == "__main__":
+def main():
     args = parse_args()
     logger = setup_logger(verbose=args.verbose)
 
@@ -340,3 +339,8 @@ if __name__ == "__main__":
         output_filename=args.output,
         logger=logger,
     )
+
+
+# ── MAIN ──────────────────────────────────────────────────────────────────────
+if __name__ == "__main__":
+    main()

--- a/cdsodatacli/scripts/match_s1_product_types.py
+++ b/cdsodatacli/scripts/match_s1_product_types.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""
+Sentinel-1 Product Matchup Tool
+Finds a target product type for a given list of Sentinel-1 SAFE product IDs.
+"""
+
+import requests
+import time
+from tqdm import tqdm
+import logging
+import argparse
+from collections import defaultdict
+from datetime import datetime
+from pathlib import Path
+from cdsodatacli.product_parser import ExplodeSAFE
+
+# ── CONFIGURATION ────────────────────────────────────────────────────────────
+ODATA_URL = "https://catalogue.dataspace.copernicus.eu/odata/v1/Products"
+
+VALID_PRODUCT_TYPES = ["GRDH", "GRDM", "SLC_", "OCN_", "RAW_"]
+
+# ── LOGGING SETUP ────────────────────────────────────────────────────────────
+def setup_logger(verbose: bool = False) -> logging.Logger:
+    logger = logging.getLogger("s1_matchup")
+    logger.setLevel(logging.DEBUG if verbose else logging.INFO)
+
+    handler = logging.StreamHandler()
+    handler.setLevel(logging.DEBUG if verbose else logging.INFO)
+
+    formatter = logging.Formatter(
+        fmt="%(asctime)s [%(levelname)s] %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S"
+    )
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    return logger
+
+
+# ── HELPERS ──────────────────────────────────────────────────────────────────
+def parse_start_time(product_name: str) -> datetime | None:
+    """Extract and parse the start timestamp from a Sentinel-1 product name."""
+    try:
+        inst = ExplodeSAFE(product_name)  # Validate format and raise if not Sentinel-1
+        return inst.startdate             # Already a datetime object
+    except (IndexError, ValueError):
+        return None
+
+
+MAX_DELTA_SECONDS = 8
+
+
+def closest_in_time(reference_dt: datetime, candidates: list[dict]) -> tuple[dict, float]:
+    """Return (candidate, delta_seconds) for the product closest in time to reference_dt."""
+    def time_delta(prod):
+        dt = parse_start_time(prod["Name"])
+        if dt is None:
+            return float("inf")
+        return abs((dt - reference_dt).total_seconds())
+
+    best = min(candidates, key=time_delta)
+    return best, time_delta(best)
+
+
+# ── CORE LOGIC ───────────────────────────────────────────────────────────────
+def find_product_for_safe(
+    source_id: str,
+    target_type: str,
+    logger: logging.Logger,
+    delta_distribution: defaultdict,
+) -> dict:
+    """
+    Finds a target-type product for a given source Sentinel-1 product ID.
+    Uses DataTake ID as the primary anchor, then exact timestamp match,
+    then closest-in-time as fallback.
+    """
+    try:
+        clean_id = source_id.replace(".SAFE", "").replace("_COG", "")
+        parts = clean_id.split("_")
+
+        platform     = parts[0]  # e.g. S1A
+        start_time   = parts[4]  # e.g. 20230726T071112
+        datatake_hex = parts[7]  # e.g. 05F692
+
+        # Normalise target type: pad to 4 chars with trailing underscore if needed
+        # so "GRDH" stays "GRDH", "SLC_" stays "SLC_", etc.
+        type_token = target_type.rstrip("_").ljust(4, "_") if len(target_type) < 4 else target_type
+
+        query_filter = (
+            f"startswith(Name,'{platform}') and "
+            f"contains(Name,'_{type_token}') and "
+            f"contains(Name,'{datatake_hex}')"
+        )
+
+        params = {"$filter": query_filter, "$top": 50}
+
+        logger.debug("OData query filter: %s", query_filter)
+
+        resp = requests.get(ODATA_URL, params=params, timeout=30)
+        if resp.status_code != 200:
+            return {
+                "source_id": source_id,
+                "status": "error",
+                "note": f"HTTP {resp.status_code}: {resp.text[:200]}"
+            }
+
+        products = resp.json().get("value", [])
+
+        if not products:
+            return {
+                "source_id": source_id,
+                "status": "not_found",
+                "note": f"No {target_type} product found for DataTake {datatake_hex}"
+            }
+
+        # ── Match strategy ───────────────────────────────────────────────────
+        # 1. Exact start-time match (same slice)
+        exact = next((p for p in products if start_time in p["Name"]), None)
+
+        if exact:
+            match = exact
+            match_method = "exact_timestamp"
+            delta_distribution[0] += 1
+
+        else:
+            # 2. Closest-in-time within the same DataTake
+            reference_dt = parse_start_time(source_id)
+
+            match, delta = closest_in_time(reference_dt, products)
+            delta_int = int(delta)
+            delta_distribution[delta_int] += 1
+
+            if delta > MAX_DELTA_SECONDS:
+                return {
+                    "source_id": source_id,
+                    "status": "not_found",
+                    "note": (
+                        f"Closest {target_type} product is {delta:.0f}s away "
+                        f"(>{MAX_DELTA_SECONDS}s threshold): {match['Name']}"
+                    ),
+                }
+            match_method = "closest_in_time"
+            logger.debug(
+                "No exact timestamp match; picked closest product "
+                "(delta=%.0fs): %s", delta, match["Name"]
+            )
+
+        return {
+            "source_id": source_id,
+            "target_id": match["Id"],
+            "target_name": match["Name"],
+            "target_type": target_type,
+            "match_method": match_method,
+            "size_mb": round(match["ContentLength"] / 1024 ** 2, 2),
+            "download_url": (
+                f"https://download.dataspace.copernicus.eu"
+                f"/odata/v1/Products({match['Id']})/$value"
+            ),
+        }
+
+    except KeyboardInterrupt:
+        raise
+    except Exception as exc:
+        return {"source_id": source_id, "status": "error", "note": str(exc)}
+
+
+# ── ENTRYPOINT ───────────────────────────────────────────────────────────────
+def entrypoint(
+    safe_list: list[str],
+    target_type: str,
+    output_filename: str,
+    logger: logging.Logger,
+) -> list[dict]:
+    logger.info(
+        "Starting matchup: %d product(s) → target type '%s'",
+        len(safe_list), target_type
+    )
+    results = []
+    delta_distribution: defaultdict[int, int] = defaultdict(int)
+    pbar = tqdm(safe_list, desc="Matching products", unit="product")
+    try:
+
+        for safe_id in pbar:
+            pbar.set_description(f" match  delta sec count: {delta_distribution}")
+            safe_id = safe_id.strip()
+            if not safe_id:
+                continue
+
+            logger.debug("Processing %s", safe_id)
+            res = find_product_for_safe(safe_id, target_type, logger, delta_distribution)
+            results.append(res)
+
+            if "target_name" in res:
+                logger.debug(
+                    "  ✓ Found (%s): %s  [%.1f MB]",
+                    res["match_method"], res["target_name"], res["size_mb"]
+                )
+            else:
+                logger.debug(
+                    "  ✗ Failed for %s — %s", safe_id, res.get("note", "unknown error")
+                )
+
+            time.sleep(0.5)  # Be polite to the OData endpoint
+
+    except KeyboardInterrupt:
+        logger.warning("Interrupted by user after %d product(s) processed.", len(results))
+
+    # ── Write results ────────────────────────────────────────────────────────
+    output_path = Path(output_filename)
+    with output_path.open("w") as fh:
+        for r in results:
+            if "target_name" in r:
+                fh.write(f"{r['target_name']}\n")
+            else:
+                fh.write(f"# NOT_FOUND: {r['source_id']} — {r.get('note', '')}\n")
+
+    found     = sum(1 for r in results if "target_name" in r)
+    not_found = sum(1 for r in results if r.get("status") == "not_found")
+    errors    = sum(1 for r in results if r.get("status") == "error")
+
+    logger.info(
+        "Done — %d found, %d not found, %d errors. Results → %s",
+        found, not_found, errors, output_path.resolve()
+    )
+
+    # ── Delta distribution ────────────────────────────────────────────────────
+    if delta_distribution:
+        logger.info("Delta-time distribution (seconds → count):")
+        for delta_s, count in sorted(delta_distribution.items()):
+            label = f"{delta_s}s" if delta_s > 0 else "exact"
+            flag  = "  ← above threshold" if delta_s > MAX_DELTA_SECONDS else ""
+            logger.info("  %6s : %d%s", label, count, flag)
+
+    return results
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Match Sentinel-1 SAFE products to a given product type via OData.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # From an inline list, look for OCN products
+  python s1_matchup.py --prodtype OCN_ \\
+      --safe S1A_IW_GRDH_1SDV_20230726T071112_... S1A_IW_GRDH_1SDV_20230726T071137_...
+
+  # From a file (one SAFE ID per line), look for SLC products
+  python s1_matchup.py --prodtype SLC_ --input-listing my_products.txt
+
+  # Enable verbose/debug logging
+  python s1_matchup.py --prodtype OCN_ --input-listing list.txt --verbose
+        """
+    )
+
+    source_group = parser.add_mutually_exclusive_group(required=True)
+    source_group.add_argument(
+        "--safe",
+        nargs="+",
+        metavar="SAFE_ID",
+        help="One or more Sentinel-1 SAFE product IDs passed directly on the command line.",
+    )
+    source_group.add_argument(
+        "--input-listing",
+        metavar="FILE",
+        help="Path to a text file with one SAFE product ID per line (blank lines ignored).",
+    )
+
+    parser.add_argument(
+        "--prodtype",
+        required=True,
+        choices=VALID_PRODUCT_TYPES,
+        metavar="TYPE",
+        help=f"Target product type to search for. Choices: {', '.join(VALID_PRODUCT_TYPES)}",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        metavar="FILE",
+        help="Output text file to write results to (one match per line).",
+    )
+    parser.add_argument(
+        "--dev",
+        action="store_true",
+        help="Enable dev mode with reduced number of SAFE to treat.",
+    )
+    parser.add_argument(
+        "--verbose", "-v",
+        action="store_true",
+        help="Enable DEBUG-level logging.",
+    )
+
+    return parser.parse_args()
+
+
+def load_listing(filepath: str, logger: logging.Logger) -> list[str]:
+    path = Path(filepath)
+    if not path.exists():
+        logger.error("Input listing file not found: %s", filepath)
+        raise SystemExit(1)
+    lines = [l.strip() for l in path.read_text().splitlines() if l.strip()]
+    logger.info("Loaded %d product ID(s) from %s", len(lines), filepath)
+    return lines
+
+
+# ── MAIN ──────────────────────────────────────────────────────────────────────
+if __name__ == "__main__":
+    args = parse_args()
+    logger = setup_logger(verbose=args.verbose)
+
+    if args.input_listing:
+        safe_list = load_listing(args.input_listing, logger)
+    else:
+        safe_list = [s.strip() for s in args.safe if s.strip()]
+
+    if args.dev:
+        safe_list = safe_list[:5]
+        logger.info("Dev mode enabled: limiting to first %d products", len(safe_list))
+
+    entrypoint(
+        safe_list=safe_list,
+        target_type=args.prodtype,
+        output_filename=args.output,
+        logger=logger,
+    )

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -39,3 +39,60 @@ For a multi-threaded download with multiple users/accounts, you can use the comm
 .. code-block:: bash
 
     downloadMuliThreadMultiUser -h
+
+
+
+Get CDSE Odata IDs for a list of products
+=========================================
+
+.. code-block:: bash
+
+    get-odata-ids -h
+        usage: get-odata-ids [-h] [--verbose] [--output-listing OUTPUT_LISTING] --input-listing INPUT_LISTING [--email EMAIL] [--password PASSWORD]
+
+        example main
+
+        options:
+        -h, --help            show this help message and exit
+        --verbose
+        --output-listing OUTPUT_LISTING
+                                output listing where the SAFE+id will be written [optional, default is input-listing+'.ids']
+        --input-listing INPUT_LISTING
+                                input SAFE listing path containing only SAFE basenames
+        --email EMAIL         email of the CDSE account to use for queries [optional, default None -> use cdsodatacli default behavior]
+        --password PASSWORD   password of the CDSE account to use for queries [optional, default None -> use cdsodatacli default behavior]
+
+
+Get equivalent S1 product types
+===============================
+
+When you have a list of Sentinel-1 products, you may want to get the equivalent product types (for example to know which S1 GRD products correspond to a list of S1 SLC products).
+You can use the command line tool `match_s1_product_types`:
+
+.. code-block:: bash
+
+    match_s1_prodtypes -h
+        usage: match_s1_prodtypes [-h] (--safe SAFE_ID [SAFE_ID ...] | --input-listing FILE) --prodtype TYPE --output FILE [--dev] [--verbose]
+
+        Match Sentinel-1 SAFE products to a given product type via OData.
+
+        options:
+        -h, --help            show this help message and exit
+        --safe SAFE_ID [SAFE_ID ...]
+                                One or more Sentinel-1 SAFE product IDs passed directly on the command line.
+        --input-listing FILE  Path to a text file with one SAFE product ID per line (blank lines ignored).
+        --prodtype TYPE       Target product type to search for. Choices: GRDH, GRDM, SLC_, OCN_, RAW_
+        --output FILE         Output text file to write results to (one match per line).
+        --dev                 Enable dev mode with reduced number of SAFE to treat.
+        --verbose, -v         Enable DEBUG-level logging.
+
+        Examples:
+        # From an inline list, look for OCN products
+        python s1_matchup.py --prodtype OCN_ \
+            --safe S1A_IW_GRDH_1SDV_20230726T071112_... S1A_IW_GRDH_1SDV_20230726T071137_...
+
+        # From a file (one SAFE ID per line), look for SLC products
+        python s1_matchup.py --prodtype SLC_ --input-listing my_products.txt
+
+        # Enable verbose/debug logging
+        python s1_matchup.py --prodtype OCN_ --input-listing list.txt --verbose

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,8 @@ downloadFromCDS = "cdsodatacli.download:main"
 downloadMuliThreadMultiUser = 'cdsodatacli.scripts.download_multithread_multiuser:entrypoint'
 downloadMultiThreadMultiUserV3 = 'cdsodatacli.script.download_multithread_one_account_deamon:entrypoint'
 countProductsLocally = 'cdsodatacli.scripts.count_present_and_absent_products:entrypoint'
-match_s1_prodrtypes = 'cdsodatacli.scripts.match_s1_product_types.py:main'
+match_s1_prodtypes = 'cdsodatacli.scripts.match_s1_product_types:main'
+get-odata-ids = 'cdsodatacli.scripts.get_ids_listing_safe_iterative:entrypoint'
 
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ downloadFromCDS = "cdsodatacli.download:main"
 downloadMuliThreadMultiUser = 'cdsodatacli.scripts.download_multithread_multiuser:entrypoint'
 downloadMultiThreadMultiUserV3 = 'cdsodatacli.script.download_multithread_one_account_deamon:entrypoint'
 countProductsLocally = 'cdsodatacli.scripts.count_present_and_absent_products:entrypoint'
+match_s1_prodrtypes = 'cdsodatacli.scripts.match_s1_product_types.py:main'
 
 
 [build-system]

--- a/tests/test_match_s1_product_types.py
+++ b/tests/test_match_s1_product_types.py
@@ -10,18 +10,21 @@ from cdsodatacli.scripts.match_s1_product_types import (
     closest_in_time,
     find_product_for_safe,
     load_listing,
-    entrypoint
+    entrypoint,
 )
+
 
 @pytest.fixture
 def logger():
     return logging.getLogger("test_logger")
 
+
 @pytest.fixture
 def real_safe_id():
     return "S1A_IW_GRDH_1SDV_20230726T071112_20230726T071137_049591_05F692_E123.SAFE"
 
-@patch('cdsodatacli.scripts.match_s1_product_types.ExplodeSAFE')
+
+@patch("cdsodatacli.scripts.match_s1_product_types.ExplodeSAFE")
 def test_parse_start_time_valid(mock_explode):
     mock_inst = MagicMock()
     mock_inst.startdate = datetime(2023, 7, 26, 7, 11, 12)
@@ -29,65 +32,99 @@ def test_parse_start_time_valid(mock_explode):
     dt = parse_start_time("S1A_ANY_STRING")
     assert dt == datetime(2023, 7, 26, 7, 11, 12)
 
-@patch('cdsodatacli.scripts.match_s1_product_types.ExplodeSAFE')
+
+@patch("cdsodatacli.scripts.match_s1_product_types.ExplodeSAFE")
 def test_parse_start_time_invalid(mock_explode):
     mock_explode.side_effect = ValueError("Invalid")
     assert parse_start_time("INVALID_NAME") is None
 
+
 def test_closest_in_time():
     ref_dt = datetime(2023, 1, 1, 12, 0, 0)
+
     def side_effect_logic(name):
-        if name == "P1": return datetime(2023, 1, 1, 12, 0, 10)
-        if name == "P2": return datetime(2023, 1, 1, 12, 0, 2)
+        if name == "P1":
+            return datetime(2023, 1, 1, 12, 0, 10)
+        if name == "P2":
+            return datetime(2023, 1, 1, 12, 0, 2)
         return None
-    with patch('cdsodatacli.scripts.match_s1_product_types.parse_start_time', side_effect=side_effect_logic):
+
+    with patch(
+        "cdsodatacli.scripts.match_s1_product_types.parse_start_time",
+        side_effect=side_effect_logic,
+    ):
         best, delta = closest_in_time(ref_dt, [{"Name": "P1"}, {"Name": "P2"}])
         assert delta == 2
         assert best["Name"] == "P2"
 
-@patch('requests.get')
-@patch('cdsodatacli.scripts.match_s1_product_types.parse_start_time')
+
+@patch("requests.get")
+@patch("cdsodatacli.scripts.match_s1_product_types.parse_start_time")
 def test_find_product_success_exact(mock_parse, mock_get, real_safe_id, logger):
     mock_parse.return_value = datetime(2023, 7, 26, 7, 11, 12)
     mock_get.return_value.status_code = 200
     mock_get.return_value.json.return_value = {
-        "value": [{"Id": "u1", "Name": "S1A_IW_OCN__1SDV_20230726T071112_...", "ContentLength": 100}]
+        "value": [
+            {
+                "Id": "u1",
+                "Name": "S1A_IW_OCN__1SDV_20230726T071112_...",
+                "ContentLength": 100,
+            }
+        ]
     }
     res = find_product_for_safe(real_safe_id, "OCN_", logger, defaultdict(int))
     assert res["match_method"] == "exact_timestamp"
 
-@patch('requests.get')
-@patch('cdsodatacli.scripts.match_s1_product_types.parse_start_time')
+
+@patch("requests.get")
+@patch("cdsodatacli.scripts.match_s1_product_types.parse_start_time")
 def test_find_product_success_closest(mock_parse, mock_get, real_safe_id, logger):
     def side_effect_logic(name):
-        if "GRDH" in name: return datetime(2023, 7, 26, 7, 11, 12)
-        return datetime(2023, 7, 26, 7, 11, 15) # 3s delta
+        if "GRDH" in name:
+            return datetime(2023, 7, 26, 7, 11, 12)
+        return datetime(2023, 7, 26, 7, 11, 15)  # 3s delta
+
     mock_parse.side_effect = side_effect_logic
     mock_get.return_value.status_code = 200
     mock_get.return_value.json.return_value = {
-        "value": [{"Id": "u2", "Name": "S1A_IW_OCN__1SDV_20230726T071115_...", "ContentLength": 100}]
+        "value": [
+            {
+                "Id": "u2",
+                "Name": "S1A_IW_OCN__1SDV_20230726T071115_...",
+                "ContentLength": 100,
+            }
+        ]
     }
     delta_dist = defaultdict(int)
     res = find_product_for_safe(real_safe_id, "OCN_", logger, delta_dist)
     assert res["match_method"] == "closest_in_time"
     assert delta_dist[3] == 1
 
-@patch('requests.get')
+
+@patch("requests.get")
 def test_find_product_not_found(mock_get, real_safe_id, logger):
     mock_get.return_value.status_code = 200
     mock_get.return_value.json.return_value = {"value": []}
     res = find_product_for_safe(real_safe_id, "OCN_", logger, defaultdict(int))
     assert res.get("status") == "not_found"
 
+
 def test_load_listing(logger):
-    with patch("pathlib.Path.read_text", return_value="P1\nP2"), \
-         patch("pathlib.Path.exists", return_value=True):
+    with (
+        patch("pathlib.Path.read_text", return_value="P1\nP2"),
+        patch("pathlib.Path.exists", return_value=True),
+    ):
         assert load_listing("d.txt", logger) == ["P1", "P2"]
 
-@patch('cdsodatacli.scripts.match_s1_product_types.find_product_for_safe')
-@patch('pathlib.Path.open', new_callable=mock_open)
+
+@patch("cdsodatacli.scripts.match_s1_product_types.find_product_for_safe")
+@patch("pathlib.Path.open", new_callable=mock_open)
 def test_entrypoint_logic(mock_file, mock_find, logger):
-    mock_find.return_value = {"source_id": "i", "target_name": "o", "match_method": "e",
-                               "size_mb": 1024.0}
+    mock_find.return_value = {
+        "source_id": "i",
+        "target_name": "o",
+        "match_method": "e",
+        "size_mb": 1024.0,
+    }
     entrypoint(["i"], "OCN_", "o.txt", logger)
     mock_file().write.assert_any_call("o\n")

--- a/tests/test_match_s1_product_types.py
+++ b/tests/test_match_s1_product_types.py
@@ -1,0 +1,93 @@
+import pytest
+from unittest.mock import MagicMock, patch, mock_open
+from datetime import datetime
+from collections import defaultdict
+import logging
+
+# Import from the script
+from cdsodatacli.scripts.match_s1_product_types import (
+    parse_start_time,
+    closest_in_time,
+    find_product_for_safe,
+    load_listing,
+    entrypoint
+)
+
+@pytest.fixture
+def logger():
+    return logging.getLogger("test_logger")
+
+@pytest.fixture
+def real_safe_id():
+    return "S1A_IW_GRDH_1SDV_20230726T071112_20230726T071137_049591_05F692_E123.SAFE"
+
+@patch('cdsodatacli.scripts.match_s1_product_types.ExplodeSAFE')
+def test_parse_start_time_valid(mock_explode):
+    mock_inst = MagicMock()
+    mock_inst.startdate = datetime(2023, 7, 26, 7, 11, 12)
+    mock_explode.return_value = mock_inst
+    dt = parse_start_time("S1A_ANY_STRING")
+    assert dt == datetime(2023, 7, 26, 7, 11, 12)
+
+@patch('cdsodatacli.scripts.match_s1_product_types.ExplodeSAFE')
+def test_parse_start_time_invalid(mock_explode):
+    mock_explode.side_effect = ValueError("Invalid")
+    assert parse_start_time("INVALID_NAME") is None
+
+def test_closest_in_time():
+    ref_dt = datetime(2023, 1, 1, 12, 0, 0)
+    def side_effect_logic(name):
+        if name == "P1": return datetime(2023, 1, 1, 12, 0, 10)
+        if name == "P2": return datetime(2023, 1, 1, 12, 0, 2)
+        return None
+    with patch('cdsodatacli.scripts.match_s1_product_types.parse_start_time', side_effect=side_effect_logic):
+        best, delta = closest_in_time(ref_dt, [{"Name": "P1"}, {"Name": "P2"}])
+        assert delta == 2
+        assert best["Name"] == "P2"
+
+@patch('requests.get')
+@patch('cdsodatacli.scripts.match_s1_product_types.parse_start_time')
+def test_find_product_success_exact(mock_parse, mock_get, real_safe_id, logger):
+    mock_parse.return_value = datetime(2023, 7, 26, 7, 11, 12)
+    mock_get.return_value.status_code = 200
+    mock_get.return_value.json.return_value = {
+        "value": [{"Id": "u1", "Name": "S1A_IW_OCN__1SDV_20230726T071112_...", "ContentLength": 100}]
+    }
+    res = find_product_for_safe(real_safe_id, "OCN_", logger, defaultdict(int))
+    assert res["match_method"] == "exact_timestamp"
+
+@patch('requests.get')
+@patch('cdsodatacli.scripts.match_s1_product_types.parse_start_time')
+def test_find_product_success_closest(mock_parse, mock_get, real_safe_id, logger):
+    def side_effect_logic(name):
+        if "GRDH" in name: return datetime(2023, 7, 26, 7, 11, 12)
+        return datetime(2023, 7, 26, 7, 11, 15) # 3s delta
+    mock_parse.side_effect = side_effect_logic
+    mock_get.return_value.status_code = 200
+    mock_get.return_value.json.return_value = {
+        "value": [{"Id": "u2", "Name": "S1A_IW_OCN__1SDV_20230726T071115_...", "ContentLength": 100}]
+    }
+    delta_dist = defaultdict(int)
+    res = find_product_for_safe(real_safe_id, "OCN_", logger, delta_dist)
+    assert res["match_method"] == "closest_in_time"
+    assert delta_dist[3] == 1
+
+@patch('requests.get')
+def test_find_product_not_found(mock_get, real_safe_id, logger):
+    mock_get.return_value.status_code = 200
+    mock_get.return_value.json.return_value = {"value": []}
+    res = find_product_for_safe(real_safe_id, "OCN_", logger, defaultdict(int))
+    assert res.get("status") == "not_found"
+
+def test_load_listing(logger):
+    with patch("pathlib.Path.read_text", return_value="P1\nP2"), \
+         patch("pathlib.Path.exists", return_value=True):
+        assert load_listing("d.txt", logger) == ["P1", "P2"]
+
+@patch('cdsodatacli.scripts.match_s1_product_types.find_product_for_safe')
+@patch('pathlib.Path.open', new_callable=mock_open)
+def test_entrypoint_logic(mock_file, mock_find, logger):
+    mock_find.return_value = {"source_id": "i", "target_name": "o", "match_method": "e",
+                               "size_mb": 1024.0}
+    entrypoint(["i"], "OCN_", "o.txt", logger)
+    mock_file().write.assert_any_call("o\n")


### PR DESCRIPTION
## Description

Idea is to have one single script for all match OCN-SLC or L1-L2.
At the end we could totally replace+remove the scripts/methods fro `s1ifr` and `stormwatch` .

- [x] add script `match_s1_product_types.py`
- [x] see whether we can multiprocess to speed up (33238 SAFE in 14h it is super long) -> skip, it is long but it works. fine for now.
- [x] add entrypoint
- [x] add unit test for this script
- [x] successful unit test `49 passed, 1 skipped, 1 warning in 25.89s`
- [x] successful end2end test
- [x] successful sphinx doc

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/cdsodatacli/cdsodatacli/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/cdsodatacli/cdsodatacli/blob/master/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
